### PR TITLE
Using C FFI for interop rust -> Python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "arrow-string",
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ pyo3 = { version = "0.18.0", features = ["extension-module", "anyhow"] }
 version = "31.0.0"
 # There's a lot of stuff we don't want here, such as serde support
 default-features = false
-features = ["ipc"]
+features = ["ipc", "ffi"]
 
 [package.metadata.maturin]
 python-source = "python"

--- a/python/fastexcel/__init__.py
+++ b/python/fastexcel/__init__.py
@@ -36,7 +36,7 @@ class ExcelSheet:
         return self._sheet.total_height
 
     def to_arrow(self) -> pa.RecordBatch:
-        """Converts the sheet to an Arrow `RecordBatch`"""
+        """Converts the sheet to a pyarrow `RecordBatch`"""
         return self._sheet.to_arrow()
 
     def to_pandas(self) -> "pd.DataFrame":

--- a/python/fastexcel/__init__.py
+++ b/python/fastexcel/__init__.py
@@ -35,7 +35,7 @@ class ExcelSheet:
         """The sheet's total height"""
         return self._sheet.total_height
 
-    def to_arrow(self) -> bytes:
+    def to_arrow(self) -> pa.RecordBatch:
         """Converts the sheet to an Arrow `RecordBatch`.
 
         The RecordBatch is serialized to the IPC format. It can be read with
@@ -49,6 +49,7 @@ class ExcelSheet:
         Requires the `pandas` extra to be installed.
         """
         # We know for sure that the sheet will yield exactly one RecordBatch
+        return self.to_arrow().to_pandas()
         return list(pa.ipc.open_stream(self.to_arrow()))[0].to_pandas()
 
     def __repr__(self) -> str:

--- a/python/fastexcel/__init__.py
+++ b/python/fastexcel/__init__.py
@@ -36,11 +36,7 @@ class ExcelSheet:
         return self._sheet.total_height
 
     def to_arrow(self) -> pa.RecordBatch:
-        """Converts the sheet to an Arrow `RecordBatch`.
-
-        The RecordBatch is serialized to the IPC format. It can be read with
-        `pyarrow.ipc.open_stream`.
-        """
+        """Converts the sheet to an Arrow `RecordBatch`"""
         return self._sheet.to_arrow()
 
     def to_pandas(self) -> "pd.DataFrame":

--- a/python/fastexcel/__init__.py
+++ b/python/fastexcel/__init__.py
@@ -50,7 +50,6 @@ class ExcelSheet:
         """
         # We know for sure that the sheet will yield exactly one RecordBatch
         return self.to_arrow().to_pandas()
-        return list(pa.ipc.open_stream(self.to_arrow()))[0].to_pandas()
 
     def __repr__(self) -> str:
         return self._sheet.__repr__()

--- a/python/fastexcel/_fastexcel.pyi
+++ b/python/fastexcel/_fastexcel.pyi
@@ -1,3 +1,5 @@
+import pyarrow as pa
+
 class _ExcelSheet:
     @property
     def name(self) -> str:
@@ -14,12 +16,8 @@ class _ExcelSheet:
     @property
     def offset(self) -> int:
         """The sheet's offset before data starts"""
-    def to_arrow(self) -> bytes:
-        """Converts the sheet to an Arrow RecordBatch.
-
-        The RecordBatch is serialized to the IPC format. It can be read with
-        `pyarrow.ipc.open_stream`.
-        """
+    def to_arrow(self) -> pa.RecordBatch:
+        """Converts the sheet to an Arrow `RecordBatch`"""
 
 class _ExcelReader:
     """A class representing an open Excel file and allowing to read its sheets"""

--- a/python/fastexcel/_fastexcel.pyi
+++ b/python/fastexcel/_fastexcel.pyi
@@ -17,7 +17,7 @@ class _ExcelSheet:
     def offset(self) -> int:
         """The sheet's offset before data starts"""
     def to_arrow(self) -> pa.RecordBatch:
-        """Converts the sheet to an Arrow `RecordBatch`"""
+        """Converts the sheet to a pyarrow `RecordBatch`"""
 
 class _ExcelReader:
     """A class representing an open Excel file and allowing to read its sheets"""

--- a/src/types/excelreader.rs
+++ b/src/types/excelreader.rs
@@ -40,7 +40,6 @@ impl ExcelReader {
 
     #[pyo3(signature = (
         name,
-        *,
         header_row = 0,
         column_names = None,
         skip_rows = 0,
@@ -67,7 +66,6 @@ impl ExcelReader {
 
     #[pyo3(signature = (
         idx,
-        *,
         header_row = 0,
         column_names = None,
         skip_rows = 0,

--- a/src/types/excelreader.rs
+++ b/src/types/excelreader.rs
@@ -40,6 +40,7 @@ impl ExcelReader {
 
     #[pyo3(signature = (
         name,
+        *,
         header_row = 0,
         column_names = None,
         skip_rows = 0,
@@ -66,6 +67,7 @@ impl ExcelReader {
 
     #[pyo3(signature = (
         idx,
+        *,
         header_row = 0,
         column_names = None,
         skip_rows = 0,

--- a/src/types/excelsheet.rs
+++ b/src/types/excelsheet.rs
@@ -11,11 +11,12 @@ use arrow::{
 };
 use calamine::{DataType as CalDataType, Range};
 
-use pyo3::prelude::*;
-
-use crate::utils::arrow::{
-    arrow_schema_from_column_names_and_range, record_batch_to_pybytes, to_python_record_batch,
+use pyo3::{
+    prelude::{pyclass, pymethods, PyObject, Python},
+    types::PyModule,
 };
+
+use crate::utils::arrow::{arrow_schema_from_column_names_and_range, to_python_record_batch};
 
 pub(crate) enum Header {
     None,
@@ -281,10 +282,9 @@ impl ExcelSheet {
         self.header.offset() + self.pagination.offset()
     }
 
-    pub fn to_arrow(&self, py: Python<'_>) -> PyResult<PyObject> {
+    pub fn to_arrow(&self, py: Python<'_>) -> Result<PyObject> {
         let rb = RecordBatch::try_from(self)
             .with_context(|| format!("Could not create RecordBatch from sheet {}", self.name))?;
-        // record_batch_to_pybytes(py, &rb).map(|pybytes| pybytes.into())
         let module = PyModule::import(py, "pyarrow").expect("pyarrow is mandatory");
         to_python_record_batch(&rb, py, module)
     }

--- a/src/types/excelsheet.rs
+++ b/src/types/excelsheet.rs
@@ -11,10 +11,7 @@ use arrow::{
 };
 use calamine::{DataType as CalDataType, Range};
 
-use pyo3::{
-    prelude::{pyclass, pymethods, PyObject, Python},
-    types::PyModule,
-};
+use pyo3::prelude::{pyclass, pymethods, PyObject, Python};
 
 use crate::utils::arrow::{arrow_schema_from_column_names_and_range, to_python_record_batch};
 
@@ -285,7 +282,7 @@ impl ExcelSheet {
     pub fn to_arrow(&self, py: Python<'_>) -> Result<PyObject> {
         let rb = RecordBatch::try_from(self)
             .with_context(|| format!("Could not create RecordBatch from sheet {}", self.name))?;
-        let module = PyModule::import(py, "pyarrow").expect("pyarrow is mandatory");
+        let module = py.import("pyarrow")?;
         to_python_record_batch(&rb, py, module)
     }
 

--- a/src/utils/arrow.rs
+++ b/src/utils/arrow.rs
@@ -1,11 +1,14 @@
 use anyhow::{anyhow, Context, Result};
 use arrow::{
+    array::ArrayRef,
     datatypes::{DataType as ArrowDataType, Field, Schema},
+    ffi::ArrowArray,
     ipc::writer::StreamWriter,
     record_batch::RecordBatch,
 };
 use calamine::{DataType as CalDataType, Range};
-use pyo3::{types::PyBytes, Python};
+use pyo3::prelude::*;
+use pyo3::{ffi::Py_uintptr_t, types::PyBytes};
 
 pub(crate) fn record_batch_to_bytes(rb: &RecordBatch) -> Result<Vec<u8>> {
     let mut writer = StreamWriter::try_new(Vec::new(), &rb.schema())
@@ -70,4 +73,43 @@ pub(crate) fn arrow_schema_from_column_names_and_range(
 
 pub(crate) fn record_batch_to_pybytes<'p>(py: Python<'p>, rb: &RecordBatch) -> Result<&'p PyBytes> {
     record_batch_to_bytes(rb).map(|bytes| PyBytes::new(py, bytes.as_slice()))
+}
+
+/// Arrow array to Python.
+pub(crate) fn to_python_array(
+    array: &ArrayRef,
+    py: Python,
+    pyarrow: &PyModule,
+) -> PyResult<PyObject> {
+    let ffi_array = ArrowArray::try_new(array.data().to_owned()).with_context(|| "haha")?;
+    let (array_ptr, schema_ptr) = ArrowArray::into_raw(ffi_array);
+    let array = pyarrow.getattr("Array")?.call_method1(
+        "_import_from_c",
+        (array_ptr as Py_uintptr_t, schema_ptr as Py_uintptr_t),
+    )?;
+    Ok(array.to_object(py))
+}
+
+/// RecordBatch to Python.
+pub(crate) fn to_python_record_batch(
+    rb: &RecordBatch,
+    py: Python,
+    pyarrow: &PyModule,
+) -> PyResult<PyObject> {
+    let mut arrays = Vec::with_capacity(rb.num_columns());
+    for array in rb.columns() {
+        let array_object = to_python_array(array, py, pyarrow)?;
+        arrays.push(array_object);
+    }
+
+    let names: Vec<String> = rb
+        .schema()
+        .all_fields()
+        .iter()
+        .map(|field| field.name().to_owned())
+        .collect();
+    let record = pyarrow
+        .getattr("RecordBatch")?
+        .call_method1("from_arrays", (arrays, names))?;
+    Ok(record.to_object(py))
 }


### PR DESCRIPTION
Was lurking the web and found this reddit post https://www.reddit.com/r/rust/comments/qy5arf/how_to_pass_dataframes_between_rust_and_python/

I tried to replicate it. After adapting to rs-arrow i got this memory usage plot.

With pybytes with a WriteStream : 
![Figure_with_pybytes](https://user-images.githubusercontent.com/39723821/215150208-256a84f6-894a-40cd-a191-2cb91f735288.png)

With a c_ffi implementation : 
![Figure_record_batch](https://user-images.githubusercontent.com/39723821/215150282-810ed8ee-b206-4a96-bc09-39ffe4e2c56e.png)

Data seem's ok so far. Maybe need to have a closer look
