### PR TITLE
feat: some slight updates for optimisations purposes

### DIFF
--- a/src/utils/arrow.rs
+++ b/src/utils/arrow.rs
@@ -53,14 +53,16 @@ pub(crate) fn arrow_schema_from_column_names_and_range(
     column_names: &[String],
     row_idx: usize,
 ) -> Result<Schema> {
-    let fields = Vec::with_capacity(column_names.len());
-
     let fields = column_names
         .iter()
         .enumerate()
         .map(|(col_idx, name)| {
             let col_type = get_arrow_column_type(range, row_idx, col_idx).unwrap();
-            Field::new(&alias_for_name(name, &fields), col_type, true)
+            Field::new(
+                alias_for_name(name, &Vec::with_capacity(column_names.len())),
+                col_type,
+                true,
+            )
         })
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
## WHAT

Small updates that may improve benchmarks + testing stuffs...


## ADDITIONAL INFOS

How to reproduce :
```console
# on main branch, after pulling this pr branch, run :
make benchmarks > before.txt && sleep 10; \
git checkout f/optimi-proposal && \
make benchmarks > after.txt
```

------


<details>

<summary>See before.txt stats: </summary>

```markdown
-------------------------------------------------------------------------------- benchmark 'xls': 2 tests --------------------------------------------------------------------------------
Name (time in ms)           Min                 Max                Mean            StdDev              Median               IQR            Outliers      OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_fastexcel_xls      35.3704 (1.0)       36.1680 (1.0)       35.6334 (1.0)      0.1881 (1.0)       35.5831 (1.0)      0.1393 (1.0)           5;3  28.0636 (1.0)          26           1
test_xlrd              470.4314 (13.30)    481.1918 (13.30)    474.9270 (13.33)    5.0093 (26.63)    472.0262 (13.27)    8.6771 (62.30)         1;0   2.1056 (0.08)          5           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------------------- benchmark 'xlsx': 4 tests -------------------------------------------------------------------------------------------
Name (time in ms)                        Min                    Max                   Mean             StdDev                 Median                IQR            Outliers     OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_fastexcel_xlsx                 623.0145 (1.0)         645.8441 (1.0)         627.9127 (1.0)      10.0305 (1.0)         623.7221 (1.0)       6.2508 (1.0)           1;1  1.5926 (1.0)           5           1
test_fastexcel_with_formulas      4,190.8753 (6.73)      4,274.5602 (6.62)      4,215.8357 (6.71)     35.0226 (3.49)      4,196.0543 (6.73)     40.6410 (6.50)          1;0  0.2372 (0.15)          5           1
test_pyxl                         4,517.8991 (7.25)      4,582.5687 (7.10)      4,554.4634 (7.25)     25.1784 (2.51)      4,561.8194 (7.31)     36.1302 (5.78)          2;0  0.2196 (0.14)          5           1
test_pyxl_with_formulas          24,629.9542 (39.53)    24,794.0673 (38.39)    24,716.8231 (39.36)    59.5044 (5.93)     24,719.9046 (39.63)    67.4244 (10.79)         2;0  0.0405 (0.03)          5           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
</details>

------


<details>
<summary>See after.txt stats:</summary>


```markdown

--------------------------------------------------------------------------------- benchmark 'xls': 2 tests ---------------------------------------------------------------------------------
Name (time in ms)           Min                 Max                Mean             StdDev              Median                IQR            Outliers      OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_fastexcel_xls      35.2180 (1.0)       35.8332 (1.0)       35.4157 (1.0)       0.1901 (1.0)       35.3479 (1.0)       0.2753 (1.0)           8;0  28.2360 (1.0)          26           1
test_xlrd              468.6557 (13.31)    491.5046 (13.72)    477.9865 (13.50)    10.5673 (55.59)    472.1987 (13.36)    18.3553 (66.68)         1;0   2.0921 (0.07)          5           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------------------- benchmark 'xlsx': 4 tests --------------------------------------------------------------------------------------------
Name (time in ms)                        Min                    Max                   Mean             StdDev                 Median                 IQR            Outliers     OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_fastexcel_xlsx                 622.3105 (1.0)         638.7867 (1.0)         626.6375 (1.0)       6.8690 (2.00)        624.6012 (1.0)        5.4269 (1.17)          1;1  1.5958 (1.0)           5           1
test_fastexcel_with_formulas      4,198.2617 (6.75)      4,207.3879 (6.59)      4,202.4733 (6.71)      3.4308 (1.0)       4,202.4523 (6.73)       4.6429 (1.0)           2;0  0.2380 (0.15)          5           1
test_pyxl                         4,579.1372 (7.36)      4,646.0339 (7.27)      4,611.2378 (7.36)     24.3193 (7.09)      4,607.3925 (7.38)      27.8000 (5.99)          2;0  0.2169 (0.14)          5           1
test_pyxl_with_formulas          24,792.4487 (39.84)    24,936.9500 (39.04)    24,872.8173 (39.69)    61.1079 (17.81)    24,884.8033 (39.84)    104.9614 (22.61)         2;0  0.0402 (0.03)          5           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
</details>