### PR TITLE
feat: introduce eager loading functions 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,9 +239,8 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "calamine"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab44c09d2f3dae84fdb1784ee6b96eddb6595c1139b8df9d3d6ba6ab25dabe2"
+version = "0.23.1"
+source = "git+https://github.com/lukapeschke/calamine?branch=public-data-type-ref#6ceb976a07bcbbbf17880b0a455f35be395e1193"
 dependencies = [
  "byteorder",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,9 +239,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "calamine"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0ba51a659bb6c8bffd6f7c1c5ffafcafa0c97e4769411d841c3cc5c154ab47"
+checksum = "cab44c09d2f3dae84fdb1784ee6b96eddb6595c1139b8df9d3d6ba6ab25dabe2"
 dependencies = [
  "byteorder",
  "chrono",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "encoding_rs",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0.76"
-calamine = { version = "0.23.0", features = ["dates"] }
+calamine = { git = "https://github.com/lukapeschke/calamine", branch = "public-data-type-ref", features = ["dates"] }
+# calamine = { version = "0.23.1", features = ["dates"] }
 chrono = { version = "0.4.31", default-features = false }
 pyo3 = { version = "0.18.3", features = ["extension-module", "anyhow"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0.76"
-calamine = { version = "0.22.1", features = ["dates"] }
+calamine = { version = "0.23.0", features = ["dates"] }
 chrono = { version = "0.4.31", default-features = false }
 pyo3 = { version = "0.18.3", features = ["extension-module", "anyhow"] }
 

--- a/python/fastexcel/__init__.py
+++ b/python/fastexcel/__init__.py
@@ -167,6 +167,37 @@ class ExcelReader:
             )
         )
 
+    def load_sheet_eager(
+        self,
+        idx_or_name: int | str,
+        *,
+        header_row: int | None = 0,
+        column_names: list[str] | None = None,
+        skip_rows: int = 0,
+        n_rows: int | None = None,
+    ) -> pa.RecordBatch:
+        """Loads a sheet by name if a string is passed or by index if an integer is passed.
+
+        See `load_sheet_by_idx` and `load_sheet_by_name` for parameter documentation.
+        """
+        return (
+            self._reader.load_sheet_by_idx_eager(
+                idx_or_name,
+                header_row=header_row,
+                column_names=column_names,
+                skip_rows=skip_rows,
+                n_rows=n_rows,
+            )
+            if isinstance(idx_or_name, int)
+            else self._reader.load_sheet_by_name_eager(
+                idx_or_name,
+                header_row=header_row,
+                column_names=column_names,
+                skip_rows=skip_rows,
+                n_rows=n_rows,
+            )
+        )
+
     def __repr__(self) -> str:
         return self._reader.__repr__()
 

--- a/python/fastexcel/_fastexcel.pyi
+++ b/python/fastexcel/_fastexcel.pyi
@@ -31,6 +31,15 @@ class _ExcelReader:
         skip_rows: int = 0,
         n_rows: int | None = None,
     ) -> _ExcelSheet: ...
+    def load_sheet_by_name_eager(
+        self,
+        name: str,
+        *,
+        header_row: int | None = 0,
+        column_names: list[str] | None = None,
+        skip_rows: int = 0,
+        n_rows: int | None = None,
+    ) -> pa.RecordBatch: ...
     def load_sheet_by_idx(
         self,
         idx: int,
@@ -40,6 +49,15 @@ class _ExcelReader:
         skip_rows: int = 0,
         n_rows: int | None = None,
     ) -> _ExcelSheet: ...
+    def load_sheet_by_idx_eager(
+        self,
+        idx: int,
+        *,
+        header_row: int | None = 0,
+        column_names: list[str] | None = None,
+        skip_rows: int = 0,
+        n_rows: int | None = None,
+    ) -> pa.RecordBatch: ...
     def load_sheet(
         self,
         idx_or_name: int | str,

--- a/python/tests/test_eagerness.py
+++ b/python/tests/test_eagerness.py
@@ -1,0 +1,32 @@
+import fastexcel
+
+from utils import path_for_fixture
+import polars as pl
+from pandas.testing import assert_frame_equal as pd_assert_frame_equal
+from polars.testing import assert_frame_equal as pl_assert_frame_equal
+
+
+def test_load_sheet_eager_single_sheet() -> None:
+    excel_reader = fastexcel.read_excel(path_for_fixture("fixture-single-sheet.xlsx"))
+
+    eager_pandas = excel_reader.load_sheet_eager(0).to_pandas()
+    lazy_pandas = excel_reader.load_sheet(0).to_pandas()
+    pd_assert_frame_equal(eager_pandas, lazy_pandas)
+
+    eager_polars = pl.from_arrow(data=excel_reader.load_sheet_eager(0))
+    assert isinstance(eager_polars, pl.DataFrame)
+    lazy_polars = excel_reader.load_sheet(0).to_polars()
+    pl_assert_frame_equal(eager_polars, lazy_polars)
+
+
+def test_multiple_sheets_with_unnamed_columns():
+    excel_reader = fastexcel.read_excel(path_for_fixture("fixture-multi-sheet.xlsx"))
+
+    eager_pandas = excel_reader.load_sheet_eager("With unnamed columns").to_pandas()
+    lazy_pandas = excel_reader.load_sheet("With unnamed columns").to_pandas()
+    pd_assert_frame_equal(eager_pandas, lazy_pandas)
+
+    eager_polars = pl.from_arrow(data=excel_reader.load_sheet_eager("With unnamed columns"))
+    assert isinstance(eager_polars, pl.DataFrame)
+    lazy_polars = excel_reader.load_sheet("With unnamed columns").to_polars()
+    pl_assert_frame_equal(eager_polars, lazy_polars)

--- a/src/utils/arrow.rs
+++ b/src/utils/arrow.rs
@@ -1,35 +1,47 @@
+use std::fmt::Debug;
+
 use anyhow::{anyhow, Context, Result};
 use arrow::datatypes::{DataType as ArrowDataType, Field, Schema, TimeUnit};
-use calamine::{DataType as CalDataType, Range};
+use calamine::{CellType, DataTypeTrait, Range};
 
-fn get_arrow_column_type(
-    data: &Range<CalDataType>,
+fn get_arrow_column_type<DT: CellType + DataTypeTrait + Debug>(
+    data: &Range<DT>,
     row: usize,
     col: usize,
 ) -> Result<ArrowDataType> {
     let cell = data
         .get((row, col))
         .with_context(|| format!("Could not retrieve data at ({row},{col})"))?;
-    match cell {
-        CalDataType::Int(_) => Ok(ArrowDataType::Int64),
-        CalDataType::Float(_) => Ok(ArrowDataType::Float64),
-        CalDataType::String(_) => Ok(ArrowDataType::Utf8),
-        CalDataType::Bool(_) => Ok(ArrowDataType::Boolean),
-        CalDataType::DateTime(_) => Ok(ArrowDataType::Timestamp(TimeUnit::Millisecond, None)),
-        // These types contain an ISO8601 representation of a date/datetime or a duration
-        CalDataType::DateTimeIso(_) => match cell.as_datetime() {
+    if cell.is_int() {
+        Ok(ArrowDataType::Int64)
+    } else if cell.is_float() {
+        Ok(ArrowDataType::Float64)
+    } else if cell.is_string() {
+        Ok(ArrowDataType::Utf8)
+    } else if cell.is_bool() {
+        Ok(ArrowDataType::Boolean)
+    } else if cell.is_datetime() {
+        Ok(ArrowDataType::Timestamp(TimeUnit::Millisecond, None))
+    }
+    // These types contain an ISO8601 representation of a date/datetime or a durat
+    else if cell.is_datetime_iso() {
+        match cell.as_datetime() {
             // If we cannot convert the cell to a datetime, we're working on a date
             Some(_) => Ok(ArrowDataType::Timestamp(TimeUnit::Millisecond, None)),
             // NOTE: not using the Date64 type on purpose, as pyarrow converts it to a datetime
             // rather than a date
             None => Ok(ArrowDataType::Date32),
-        },
-        CalDataType::DurationIso(_) => Ok(ArrowDataType::Duration(TimeUnit::Millisecond)),
-        // A simple duration
-        CalDataType::Duration(_) => Ok(ArrowDataType::Duration(TimeUnit::Millisecond)),
-        // Errors and nulls
-        CalDataType::Error(err) => Err(anyhow!("Error in calamine cell: {err:?}")),
-        CalDataType::Empty => Ok(ArrowDataType::Null),
+        }
+    }
+    // Simple durations
+    else if cell.is_duration() || cell.is_duration_iso() {
+        Ok(ArrowDataType::Duration(TimeUnit::Millisecond))
+    } else if cell.is_empty() {
+        Ok(ArrowDataType::Null)
+    }
+    // Error datatype
+    else {
+        Err(anyhow!("Unexpected cell type: {cell:?}"))
     }
 }
 
@@ -49,8 +61,8 @@ fn alias_for_name(name: &str, fields: &[Field]) -> String {
     rec(name, fields, 0)
 }
 
-pub(crate) fn arrow_schema_from_column_names_and_range(
-    range: &Range<CalDataType>,
+pub(crate) fn arrow_schema_from_column_names_and_range<DT: CellType + DataTypeTrait + Debug>(
+    range: &Range<DT>,
     column_names: &[String],
     row_idx: usize,
 ) -> Result<Schema> {


### PR DESCRIPTION
# What

This introduces eager loading functions that make use of the calamine's new `DataTypeRef`. 

This prevents some allocations, resulting in a lower memory footprint.

# Caveats

* The API is kinda rough for now, it will probably need some cleaning (I mostly wanted to check if the memory gain was interesting here).

* The functions need to be eager because `DataTypeRef` has an explicit lifetime, which is not allowed by PyO3 (lifetimes are hard to enforce on the python side: https://pyo3.rs/v0.20.0/class.html#no-lifetime-parameters)

# Gains

While the speed stays roughly the same (it was even 3~5% faster on my machine on several tests), **the memory footprint decreases by almost 25%.** . This means that we're almost as good as pandas memory-wise :partying_face:  (they still beat us by a few MBs), while being about 10 times faster

## Before

![before](https://github.com/ToucanToco/fastexcel/assets/17085536/38adb4e6-cc50-4bdb-affe-e9b2d28b2ef9)

## After

![after](https://github.com/ToucanToco/fastexcel/assets/17085536/75f094db-99ac-4690-aebd-b1d5576bd2f7)

## Pandas

![pandas](https://github.com/ToucanToco/fastexcel/assets/17085536/96729469-5f18-43c1-b34e-2d62fb3a3753)
