### PR TITLE
feat: extend `fastexcel` support to python >= 3.8

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: build (fast)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python python3.10
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: "${{ matrix.python-version }}"
@@ -49,7 +49,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: build (fast)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: build (release)
@@ -30,7 +30,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: build (release)
@@ -51,6 +51,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: [linux, macos]
     steps:
+    - name: Download Linux 3.8 wheels
+      uses: actions/download-artifact@v4
+      with:
+        name: "wheels-linux-python-3.8"
+        path: wheels-linux
+    - name: Download Linux 3.9 wheels
+      uses: actions/download-artifact@v4
+      with:
+        name: "wheels-linux-python-3.9"
+        path: wheels-linux
     - name: Download Linux 3.10 wheels
       uses: actions/download-artifact@v4
       with:
@@ -67,6 +77,16 @@ jobs:
         name: "wheels-linux-python-3.12"
         path: wheels-linux
 
+    - name: Download MacOS 3.8 wheels
+      uses: actions/download-artifact@v4
+      with:
+        name: "wheels-macos-python-3.8"
+        path: wheels-macos
+    - name: Download MacOS 3.9 wheels
+      uses: actions/download-artifact@v4
+      with:
+        name: "wheels-macos-python-3.9"
+        path: wheels-macos
     - name: Download MacOS 3.10 wheels
       uses: actions/download-artifact@v4
       with:
@@ -98,3 +118,4 @@ jobs:
         files: |
           wheels-linux/*.whl
           wheels-macos/*.whl
+8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,4 +118,3 @@ jobs:
         files: |
           wheels-linux/*.whl
           wheels-macos/*.whl
-8

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@ __pycache__
 *.pyc
 *.so
 *.dat
+
 .python-version
 .venv
 docs
+.idea
 .benchmarks

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Docs available [here](https://fastexcel.toucantoco.dev/).
 
 ### Prerequisites
 
-Python>=3.10 and a recent Rust toolchain must be installed on your machine. `cargo` must be available in your `PATH`.
+Python>=3.8 and a recent Rust toolchain must be installed on your machine. `cargo` must be available in your `PATH`.
 
 ### First setup
 
@@ -31,7 +31,7 @@ This will compile the wheel (in debug mode) and install it. It will then be avai
 
 ### Installing the project in prod mode
 
-This is required for profiling, as dev mdoe wheels are much slower. `make prod-install` will compile the project
+This is required for profiling, as dev mode wheels are much slower. `make prod-install` will compile the project
 in release mode and install it in your local venv, overriding previous dev installs.
 
 ### Linting and formatting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "fastexcel"
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -27,7 +27,7 @@ python-source = "python"
 module-name = "fastexcel._fastexcel"
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.8"
 follow_imports = "silent"
 ignore_missing_imports = true
 # A few custom options
@@ -45,4 +45,4 @@ testpaths = [
 line-length = 100
 
 # Enable Pyflakes `E` and `F` codes by default.
-select = ["E", "F", "Q"]
+select = ["E", "F", "I", "Q", "FA102"]

--- a/python/fastexcel/__init__.py
+++ b/python/fastexcel/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/python/fastexcel/_fastexcel.pyi
+++ b/python/fastexcel/_fastexcel.pyi
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pyarrow as pa
 
 class _ExcelSheet:

--- a/python/tests/benchmarks/memory.py
+++ b/python/tests/benchmarks/memory.py
@@ -1,5 +1,6 @@
-from enum import Enum
 import argparse
+from enum import Enum
+
 from readers import fastexcel_read, pyxl_read, xlrd_read
 
 
@@ -18,13 +19,14 @@ def get_args() -> argparse.Namespace:
 
 def main():
     args = get_args()
-    match args.engine:
-        case Engine.FASTEXCEL:
-            fastexcel_read(args.file)
-        case Engine.XLRD:
-            xlrd_read(args.file)
-        case Engine.OPENPYXL:
-            pyxl_read(args.file)
+    engine = args.engine
+
+    if engine == Engine.FASTEXCEL:
+        fastexcel_read(args.file)
+    elif engine == Engine.XLRD:
+        xlrd_read(args.file)
+    elif engine == Engine.OPENPYXL:
+        pyxl_read(args.file)
 
 
 if __name__ == "__main__":

--- a/python/tests/test_durations.py
+++ b/python/tests/test_durations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import date, datetime, timedelta
 
 import fastexcel
@@ -11,7 +13,6 @@ from polars.datatypes import Duration as PlDuration
 from polars.datatypes import PolarsDataType
 from polars.datatypes import Utf8 as PlUtf8
 from polars.testing import assert_frame_equal as pl_assert_frame_equal
-
 from utils import path_for_fixture
 
 

--- a/python/tests/test_empty.py
+++ b/python/tests/test_empty.py
@@ -1,6 +1,5 @@
 import fastexcel
 import pytest
-
 from utils import path_for_fixture
 
 

--- a/python/tests/test_fastexcel.py
+++ b/python/tests/test_fastexcel.py
@@ -4,7 +4,6 @@ import polars as pl
 import pytest
 from pandas.testing import assert_frame_equal as pd_assert_frame_equal
 from polars.testing import assert_frame_equal as pl_assert_frame_equal
-
 from utils import path_for_fixture
 
 


### PR DESCRIPTION
Hoping that a patch to extend Python support is welcome :wink:  

I was looking to integrate a `calamine` based Excel parser as one of our supported engines in the Polars `read_excel` method (I am one of the core devs for that project), but we need to support Python versions >= 3.8. While we could potentially have `python_calamine` handle earlier versions, I'm reluctant to do so as `fastexcel` is much better-suited for our use-case and benchmarks significantly faster (producing Arrow data without materialising anything in Python-space; nicely done!)

Took a look at the code to see if it could be extended to cover the earlier versions, and it seems like a straightforward low-impact update; I've validated that everything compiles/runs on the earlier Python versions (testing on x86 Ubuntu Linux for py3.8 and an Apple Silicon Mac for py3.9). Mostly just some minor typing updates and avoidance of the `match` expression in one of the tests. Put in an extra lint rule to catch the need for a `from __future__ import annotations` statement at the top of some files (to keep the modern typing syntax).

I can't validate the workflow changes, but with a little luck they'll run ok 🤞

Thanks for the great work, and let me know if you want any changes/modifications, etc?
