### PR TITLE
feat(build): build abi3 wheels

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,7 +86,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # Only testing the build on the smallest supported Python version
+        # since we're building abi3 wheels
+        python-version: ["3.8"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         architecture: [x86-64, aarch64]
         exclude:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8"]
     steps:
     - uses: actions/checkout@v4
     - name: build (release)
@@ -30,7 +30,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8"]
     steps:
     - uses: actions/checkout@v4
     - name: build (release)
@@ -49,7 +49,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8"]
     steps:
     - uses: actions/checkout@v4
     - name: build (release)
@@ -74,77 +74,17 @@ jobs:
       with:
         name: "wheels-linux-python-3.8"
         path: wheels-linux
-    - name: Download Linux 3.9 wheels
-      uses: actions/download-artifact@v4
-      with:
-        name: "wheels-linux-python-3.9"
-        path: wheels-linux
-    - name: Download Linux 3.10 wheels
-      uses: actions/download-artifact@v4
-      with:
-        name: "wheels-linux-python-3.10"
-        path: wheels-linux
-    - name: Download Linux 3.11 wheels
-      uses: actions/download-artifact@v4
-      with:
-        name: "wheels-linux-python-3.11"
-        path: wheels-linux
-    - name: Download Linux 3.12 wheels
-      uses: actions/download-artifact@v4
-      with:
-        name: "wheels-linux-python-3.12"
-        path: wheels-linux
 
     - name: Download MacOS 3.8 wheels
       uses: actions/download-artifact@v4
       with:
         name: "wheels-macos-python-3.8"
         path: wheels-macos
-    - name: Download MacOS 3.9 wheels
-      uses: actions/download-artifact@v4
-      with:
-        name: "wheels-macos-python-3.9"
-        path: wheels-macos
-    - name: Download MacOS 3.10 wheels
-      uses: actions/download-artifact@v4
-      with:
-        name: "wheels-macos-python-3.10"
-        path: wheels-macos
-    - name: Download MacOS 3.11 wheels
-      uses: actions/download-artifact@v4
-      with:
-        name: "wheels-macos-python-3.11"
-        path: wheels-macos
-    - name: Download MacOS 3.12 wheels
-      uses: actions/download-artifact@v4
-      with:
-        name: "wheels-macos-python-3.12"
-        path: wheels-macos
 
     - name: Download Windows 3.8 wheels
       uses: actions/download-artifact@v4
       with:
         name: "wheels-windows-python-3.8"
-        path: wheels-windows
-    - name: Download Windows 3.9 wheels
-      uses: actions/download-artifact@v4
-      with:
-        name: "wheels-windows-python-3.9"
-        path: wheels-windows
-    - name: Download Windows 3.10 wheels
-      uses: actions/download-artifact@v4
-      with:
-        name: "wheels-windows-python-3.10"
-        path: wheels-windows
-    - name: Download Windows 3.11 wheels
-      uses: actions/download-artifact@v4
-      with:
-        name: "wheels-windows-python-3.11"
-        path: wheels-windows
-    - name: Download Windows 3.12 wheels
-      uses: actions/download-artifact@v4
-      with:
-        name: "wheels-windows-python-3.12"
         path: wheels-windows
 
     - name: Publish to PyPI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 anyhow = "1.0.80"
 calamine = { version = "0.24.0", features = ["dates"] }
 chrono = { version = "0.4.34", default-features = false }
-pyo3 = { version = "0.18.3", features = ["extension-module", "anyhow"] }
+pyo3 = { version = "0.18.3", features = ["extension-module", "anyhow", "abi3-py38"] }
 
 [dependencies.arrow]
 version = "40.0.0"


### PR DESCRIPTION
This simplifies our wheel build process by using the abi3 API.

https://pyo3.rs/v0.14.5/building_and_distribution#py_limited_apiabi3

It allows us to build only a single wheel per target OS/arch.

closes #168