### PR TITLE
fix: raise `SheetNotFoundError` when reading a missing sheet name

### DIFF
--- a/python/tests/test_errors.py
+++ b/python/tests/test_errors.py
@@ -31,7 +31,7 @@ def test_sheet_idx_not_found_error() -> None:
     excel_reader = fastexcel.read_excel(path_for_fixture("fixture-single-sheet.xlsx"))
     expected_message = """sheet at index 42 not found
 Context:
-    0: Sheet index 42 is out of range. File has 1 sheets"""
+    0: Sheet index 42 is out of range. File has 1 sheets."""
 
     with pytest.raises(fastexcel.SheetNotFoundError, match=expected_message) as exc_info:
         excel_reader.load_sheet(42)
@@ -47,7 +47,7 @@ def test_sheet_name_not_found_error() -> None:
     excel_reader = fastexcel.read_excel(path_for_fixture("fixture-single-sheet.xlsx"))
     expected_message = """sheet with name "idontexist" not found
 Context:
-    0: Sheet idontexist not found in file. Available sheets: January"""
+    0: Sheet "idontexist" not found in file. Available sheets: "January"."""
 
     with pytest.raises(fastexcel.SheetNotFoundError, match=expected_message) as exc_info:
         excel_reader.load_sheet("idontexist")

--- a/python/tests/test_errors.py
+++ b/python/tests/test_errors.py
@@ -27,7 +27,7 @@ Context:
         fastexcel.read_excel("path_does_not_exist.nope")
 
 
-def test_sheet_not_found_error() -> None:
+def test_sheet_idx_not_found_error() -> None:
     excel_reader = fastexcel.read_excel(path_for_fixture("fixture-single-sheet.xlsx"))
     expected_message = """sheet at index 42 not found
 Context:
@@ -41,6 +41,18 @@ Context:
     # Should also work with the base error type
     with pytest.raises(fastexcel.FastExcelError, match=expected_message):
         excel_reader.load_sheet(42)
+
+
+def test_sheet_name_not_found_error() -> None:
+    excel_reader = fastexcel.read_excel(path_for_fixture("fixture-single-sheet.xlsx"))
+    expected_message = """sheet with name "idontexist" not found
+Context:
+    0: Sheet idontexist not found in file. Available sheets: January"""
+
+    with pytest.raises(fastexcel.SheetNotFoundError, match=expected_message) as exc_info:
+        excel_reader.load_sheet("idontexist")
+
+    assert exc_info.value.__doc__ == "Sheet was not found"
 
 
 @pytest.mark.parametrize(

--- a/src/types/python/excelreader.rs
+++ b/src/types/python/excelreader.rs
@@ -149,9 +149,9 @@ impl ExcelReader {
                         Ok(name)
                     } else {
                         Err(FastExcelErrorKind::SheetNotFound(IdxOrName::Name(name.clone())).into()).with_context(||  {
-                            let available_sheets = self.sheet_names.join(", ");
+                            let available_sheets = self.sheet_names.iter().map(|s| format!("\"{s}\"")).collect::<Vec<_>>().join(", ");
                             format!(
-                                "Sheet {name} not found in file. Available sheets: {available_sheets}"
+                                "Sheet \"{name}\" not found in file. Available sheets: {available_sheets}."
                             )
                         })
                     }
@@ -162,7 +162,7 @@ impl ExcelReader {
                     .ok_or_else(|| FastExcelErrorKind::SheetNotFound(IdxOrName::Idx(idx)).into())
                     .with_context(|| {
                         format!(
-                            "Sheet index {idx} is out of range. File has {} sheets",
+                            "Sheet index {idx} is out of range. File has {} sheets.",
                             self.sheet_names.len()
                         )
                     })

--- a/src/types/python/excelreader.rs
+++ b/src/types/python/excelreader.rs
@@ -144,7 +144,18 @@ impl ExcelReader {
         let name = idx_or_name
             .try_into()
             .and_then(|idx_or_name| match idx_or_name {
-                IdxOrName::Name(name) => Ok(name),
+                IdxOrName::Name(name) => {
+                    if self.sheet_names.contains(&name) {
+                        Ok(name)
+                    } else {
+                        Err(FastExcelErrorKind::SheetNotFound(IdxOrName::Name(name.clone())).into()).with_context(||  {
+                            let available_sheets = self.sheet_names.join(", ");
+                            format!(
+                                "Sheet {name} not found in file. Available sheets: {available_sheets}"
+                            )
+                        })
+                    }
+                }
                 IdxOrName::Idx(idx) => self
                     .sheet_names
                     .get(idx)


### PR DESCRIPTION
closes #221 