### PR TITLE
fix: add `typing-extensions` to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
 ]
 dependencies = [
     "pyarrow>=8.0.0",
+    "typing-extensions >=4.0.0,< 5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
 ]
 dependencies = [
     "pyarrow>=8.0.0",
-    "typing-extensions>=4.6.1; python_version<'3.10'",
+    "typing-extensions>=4.0.0; python_version<'3.10'",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
 ]
 dependencies = [
     "pyarrow>=8.0.0",
-    "typing-extensions >=4.0.0,< 5.0.0",
+    "typing-extensions>=4.6.1; python_version<'3.10'",
 ]
 
 [project.optional-dependencies]

--- a/python/fastexcel/__init__.py
+++ b/python/fastexcel/__init__.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, Literal
 
-from typing_extensions import TypeAlias
+if sys.version_info < (3, 10):
+    from typing_extensions import TypeAlias
+else:
+    from typing import TypeAlias
 
 if TYPE_CHECKING:
     import pandas as pd


### PR DESCRIPTION
## Purpose of This PR
This PR incorporates `typing-extensions` into `fastexcel`'s dependencies, addressing Issue #226.

## Outcomes
This update resolves a subtle bug in the `polars` library's `read_excel` function, specifically when utilizing the `calamine` engine.

Before this change, attempting to use the `calamine` engine would trigger an erroneous message from `polars`, indicating that `fastexcel` was not installed, despite its presence. This issue stemmed from the absence of the `typing-extensions` dependency.

## Testing
All test are passing after running `make test`.