### PR TITLE
chore(deps): bump pyo3 0.20.3 -> 0.21.2 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219d05930b81663fd3b32e3bde8ce5bff3c4d23052a99f11a8fa50a3b47b2658"
+checksum = "7ae9728f104939be6d8d9b368a354b4929b0569160ea1641f0721b55a861ce38"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0272150200c07a86a390be651abdd320a2d12e84535f0837566ca87ecd8f95e0"
+checksum = "a7029a5b3efbeafbf4a12d12dc16b8f9e9bff20a410b8c25c5d28acc089e1043"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8010572cf8c745e242d1b632bd97bd6d4f40fefed5ed1290a8f433abaa686fea"
+checksum = "d33238427c60271710695f17742f45b1a5dc5bcfc5c15331c25ddfe7abf70d97"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0a2432f0cba5692bf4cb757469c66791394bac9ec7ce63c1afe74744c37b27"
+checksum = "fe9b95e825ae838efaf77e366c00d3fc8cca78134c9db497d6bda425f2e7b7c1"
 dependencies = [
  "bytes",
  "half",
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abc10cd7995e83505cc290df9384d6e5412b207b79ce6bdff89a10505ed2cba"
+checksum = "87cf8385a9d5b5fcde771661dd07652b79b9139fea66193eda6a88664400ccab"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2742ac1f6650696ab08c88f6dd3f0eb68ce10f8c253958a18c943a68cd04aec5"
+checksum = "cb29be98f987bcf217b070512bb7afba2f65180858bca462edf4a39d84a23e10"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e6b61e3dc468f503181dccc2fc705bdcc5f2f146755fa5b56d0a6c5943f412"
+checksum = "fcb56ed1547004e12203652f12fe12e824161ff9d1e5cf2a7dc4ff02ba94f413"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848ee52bb92eb459b811fb471175ea3afcf620157674c8794f539838920f9228"
+checksum = "575b42f1fc588f2da6977b94a5ca565459f5ab07b60545e17243fb9a7ed6d43e"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -179,18 +179,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d9483aaabe910c4781153ae1b6ae0393f72d9ef757d38d09d450070cf2e528"
+checksum = "32aae6a60458a2389c0da89c9de0b7932427776127da1a738e2efc21d32f3393"
 dependencies = [
  "bitflags 2.0.2",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849524fa70e0e3c5ab58394c770cb8f514d0122d20de08475f7b472ed8075830"
+checksum = "de36abaef8767b4220d7b4a8c2fe5ffc78b47db81b03d77e2136091c3ba39102"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9373cb5a021aee58863498c37eb484998ef13377f69989c6c5ccfbd258236cdb"
+checksum = "e435ada8409bcafc910bc3e0077f532a4daa20e99060a496685c0e3e53cc2597"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -825,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -835,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -847,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1017,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.4"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ crate-type = ["cdylib"]
 calamine = { version = "0.25.0", features = ["dates"] }
 chrono = { version = "0.4.38", default-features = false }
 # NOTE: "extension-module" is actually required, see comments on features below
-pyo3 = { version = "0.20.3", features = ["abi3-py38"] }
+pyo3 = { version = "0.21.2", features = ["abi3-py38"] }
 
 [dependencies.arrow]
-version = "51.0.0"
+version = "52.0.0"
 # There's a lot of stuff we don't want here, such as serde support
 default-features = false
 features = ["pyarrow"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.3.2,<2.0"]
+requires = ["maturin>=1.6.0,<2.0"]
 build-backend = "maturin"
 
 [project]
@@ -25,6 +25,7 @@ Issues = "https://github.com/ToucanToco/fastexcel"
 [tool.maturin]
 python-source = "python"
 module-name = "fastexcel._fastexcel"
+features = ["pyo3/extension-module"]
 
 [tool.mypy]
 python_version = "3.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ mod types;
 mod utils;
 
 use error::{py_errors, ErrorContext};
-use pyo3::prelude::*;
+use pyo3::{prelude::*, types::PyString};
 use types::python::{excelsheet::column_info::ColumnInfo, ExcelReader, ExcelSheet};
 
 /// Reads an excel file and returns an object allowing to access its sheets and a bit of metadata
@@ -11,7 +11,8 @@ use types::python::{excelsheet::column_info::ColumnInfo, ExcelReader, ExcelSheet
 fn read_excel(source: &PyAny) -> PyResult<ExcelReader> {
     use py_errors::IntoPyResult;
 
-    if let Ok(path) = source.extract::<&str>() {
+    if let Ok(path) = source.extract::<&PyString>() {
+        let path = path.to_str()?;
         ExcelReader::try_from_path(path)
             .with_context(|| format!("could not load excel file at {path}"))
             .into_pyresult()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use types::python::{excelsheet::column_info::ColumnInfo, ExcelReader, ExcelSheet
 
 /// Reads an excel file and returns an object allowing to access its sheets and a bit of metadata
 #[pyfunction]
-fn read_excel(source: &PyAny) -> PyResult<ExcelReader> {
+fn read_excel(source: &Bound<'_, PyAny>) -> PyResult<ExcelReader> {
     use py_errors::IntoPyResult;
 
     if let Ok(path) = source.extract::<&PyString>() {
@@ -40,7 +40,8 @@ fn get_version() -> String {
 }
 
 #[pymodule]
-fn _fastexcel(py: Python, m: &PyModule) -> PyResult<()> {
+fn _fastexcel(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    let py = m.py();
     m.add_function(wrap_pyfunction!(read_excel, m)?)?;
     m.add_class::<ColumnInfo>()?;
     m.add_class::<ExcelSheet>()?;
@@ -49,32 +50,38 @@ fn _fastexcel(py: Python, m: &PyModule) -> PyResult<()> {
 
     // errors
     [
-        ("FastExcelError", py.get_type::<py_errors::FastExcelError>()),
+        (
+            "FastExcelError",
+            py.get_type_bound::<py_errors::FastExcelError>(),
+        ),
         (
             "UnsupportedColumnTypeCombinationError",
-            py.get_type::<py_errors::UnsupportedColumnTypeCombinationError>(),
+            py.get_type_bound::<py_errors::UnsupportedColumnTypeCombinationError>(),
         ),
         (
             "CannotRetrieveCellDataError",
-            py.get_type::<py_errors::CannotRetrieveCellDataError>(),
+            py.get_type_bound::<py_errors::CannotRetrieveCellDataError>(),
         ),
         (
             "CalamineCellError",
-            py.get_type::<py_errors::CalamineCellError>(),
+            py.get_type_bound::<py_errors::CalamineCellError>(),
         ),
-        ("CalamineError", py.get_type::<py_errors::CalamineError>()),
+        (
+            "CalamineError",
+            py.get_type_bound::<py_errors::CalamineError>(),
+        ),
         (
             "SheetNotFoundError",
-            py.get_type::<py_errors::SheetNotFoundError>(),
+            py.get_type_bound::<py_errors::SheetNotFoundError>(),
         ),
         (
             "ColumnNotFoundError",
-            py.get_type::<py_errors::ColumnNotFoundError>(),
+            py.get_type_bound::<py_errors::ColumnNotFoundError>(),
         ),
-        ("ArrowError", py.get_type::<py_errors::ArrowError>()),
+        ("ArrowError", py.get_type_bound::<py_errors::ArrowError>()),
         (
             "InvalidParametersError",
-            py.get_type::<py_errors::InvalidParametersError>(),
+            py.get_type_bound::<py_errors::InvalidParametersError>(),
         ),
     ]
     .into_iter()

--- a/src/types/dtype.rs
+++ b/src/types/dtype.rs
@@ -7,7 +7,10 @@ use std::{
 
 use arrow::datatypes::{DataType as ArrowDataType, TimeUnit};
 use calamine::{CellErrorType, CellType, DataType, Range};
-use pyo3::{types::PyString, FromPyObject, PyAny, PyObject, PyResult, Python, ToPyObject};
+use pyo3::{
+    prelude::PyAnyMethods, types::PyString, Bound, FromPyObject, PyAny, PyObject, PyResult, Python,
+    ToPyObject,
+};
 
 use crate::error::{py_errors::IntoPyResult, FastExcelError, FastExcelErrorKind, FastExcelResult};
 
@@ -68,7 +71,7 @@ impl ToPyObject for DType {
 }
 
 impl FromPyObject<'_> for DType {
-    fn extract(py_dtype: &PyAny) -> PyResult<Self> {
+    fn extract_bound(py_dtype: &Bound<'_, PyAny>) -> PyResult<Self> {
         if let Ok(dtype_pystr) = py_dtype.extract::<&PyString>() {
             dtype_pystr.to_str()?.parse()
         } else {

--- a/src/types/dtype.rs
+++ b/src/types/dtype.rs
@@ -7,7 +7,7 @@ use std::{
 
 use arrow::datatypes::{DataType as ArrowDataType, TimeUnit};
 use calamine::{CellErrorType, CellType, DataType, Range};
-use pyo3::{FromPyObject, PyAny, PyObject, PyResult, Python, ToPyObject};
+use pyo3::{types::PyString, FromPyObject, PyAny, PyObject, PyResult, Python, ToPyObject};
 
 use crate::error::{py_errors::IntoPyResult, FastExcelError, FastExcelErrorKind, FastExcelResult};
 
@@ -69,8 +69,8 @@ impl ToPyObject for DType {
 
 impl FromPyObject<'_> for DType {
     fn extract(py_dtype: &PyAny) -> PyResult<Self> {
-        if let Ok(dtype_str) = py_dtype.extract::<&str>() {
-            dtype_str.parse()
+        if let Ok(dtype_pystr) = py_dtype.extract::<&PyString>() {
+            dtype_pystr.to_str()?.parse()
         } else {
             Err(FastExcelErrorKind::InvalidParameters(format!(
                 "{py_dtype:?} cannot be converted to str"

--- a/src/types/idx_or_name.rs
+++ b/src/types/idx_or_name.rs
@@ -1,4 +1,6 @@
-use pyo3::{FromPyObject, PyAny, PyObject, PyResult, Python, ToPyObject};
+use pyo3::{
+    prelude::PyAnyMethods, Bound, FromPyObject, PyAny, PyObject, PyResult, Python, ToPyObject,
+};
 
 use crate::error::{py_errors::IntoPyResult, FastExcelError, FastExcelErrorKind, FastExcelResult};
 
@@ -17,10 +19,10 @@ impl IdxOrName {
     }
 }
 
-impl TryFrom<&PyAny> for IdxOrName {
+impl TryFrom<&Bound<'_, PyAny>> for IdxOrName {
     type Error = FastExcelError;
 
-    fn try_from(value: &PyAny) -> FastExcelResult<Self> {
+    fn try_from(value: &Bound<'_, PyAny>) -> FastExcelResult<Self> {
         if let Ok(index) = value.extract() {
             Ok(Self::Idx(index))
         } else if let Ok(name) = value.extract() {
@@ -35,8 +37,8 @@ impl TryFrom<&PyAny> for IdxOrName {
 }
 
 impl FromPyObject<'_> for IdxOrName {
-    fn extract(value: &PyAny) -> PyResult<Self> {
-        value.try_into().into_pyresult()
+    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+        ob.try_into().into_pyresult()
     }
 }
 

--- a/src/types/python/excelreader.rs
+++ b/src/types/python/excelreader.rs
@@ -11,7 +11,7 @@ use arrow::{
 use calamine::{
     open_workbook_auto, open_workbook_auto_from_rs, Data, DataRef, Range, Reader, Sheets,
 };
-use pyo3::{prelude::PyObject, pyclass, pymethods, IntoPy, PyAny, PyResult, Python};
+use pyo3::{prelude::PyObject, pyclass, pymethods, Bound, IntoPy, PyAny, PyResult, Python};
 
 use crate::{
     error::{
@@ -81,7 +81,9 @@ pub(crate) struct ExcelReader {
 }
 
 impl ExcelReader {
-    fn build_selected_columns(use_columns: Option<&PyAny>) -> FastExcelResult<SelectedColumns> {
+    fn build_selected_columns(
+        use_columns: Option<&Bound<'_, PyAny>>,
+    ) -> FastExcelResult<SelectedColumns> {
         use_columns.try_into().with_context(|| format!("expected selected columns to be list[str] | list[int] | str | None, got {use_columns:?}"))
     }
 
@@ -148,7 +150,7 @@ impl ExcelReader {
         skip_rows: usize,
         n_rows: Option<usize>,
         schema_sample_rows: Option<usize>,
-        use_columns: Option<&PyAny>,
+        use_columns: Option<&Bound<'_, PyAny>>,
         dtypes: Option<DTypeMap>,
         eager: bool,
         py: Python<'_>,
@@ -229,13 +231,13 @@ impl ExcelReader {
     #[allow(clippy::too_many_arguments)]
     pub fn load_sheet(
         &mut self,
-        idx_or_name: &PyAny,
+        idx_or_name: &Bound<'_, PyAny>,
         header_row: Option<usize>,
         column_names: Option<Vec<String>>,
         skip_rows: usize,
         n_rows: Option<usize>,
         schema_sample_rows: Option<usize>,
-        use_columns: Option<&PyAny>,
+        use_columns: Option<&Bound<'_, PyAny>>,
         dtypes: Option<DTypeMap>,
         eager: bool,
         py: Python<'_>,


### PR DESCRIPTION
This bumps pyo3 to v0.21, which introduces a new API: 
* https://pyo3.rs/v0.21.2/migration#from-020-to-021
* https://polar.sh/davidhewitt/posts/replacing-pyo3-api-pt1