### PR TITLE
fix: respect provided column ordering in use_columns when loading a sheet eagerly

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def expected_data_sheet_null_strings() -> dict[str, list[Any]]:
+    return {
+        "FIRST_LABEL": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+        "SECOND_LABEL": ["AA", "BB", "CC", "DD", "EE", "FF", "GG", "HH", "II", "JJ"],
+        "DATES_AND_NULLS": [
+            None,
+            None,
+            None,
+            datetime(2022, 12, 19, 0, 0),
+            datetime(2022, 8, 26, 0, 0),
+            datetime(2023, 5, 6, 0, 0),
+            datetime(2023, 3, 20, 0, 0),
+            datetime(2022, 8, 29, 0, 0),
+            None,
+            None,
+        ],
+        "TIMESTAMPS_AND_NULLS": [
+            None,
+            None,
+            datetime(2023, 2, 18, 6, 13, 56, 730000),
+            datetime(2022, 9, 20, 20, 0, 7, 50000),
+            datetime(2022, 9, 24, 17, 4, 31, 236000),
+            None,
+            None,
+            None,
+            datetime(2022, 9, 14, 1, 50, 58, 390000),
+            datetime(2022, 10, 21, 17, 20, 12, 223000),
+        ],
+        "INTS_AND_NULLS": [
+            2076.0,
+            2285.0,
+            39323.0,
+            None,
+            None,
+            None,
+            11953.0,
+            None,
+            30192.0,
+            None,
+        ],
+        "FLOATS_AND_NULLS": [
+            141.02023312814603,
+            778.0655928608671,
+            None,
+            497.60307287584106,
+            627.446112513911,
+            None,
+            None,
+            None,
+            488.3509486743364,
+            None,
+        ],
+    }

--- a/python/tests/test_fastexcel.py
+++ b/python/tests/test_fastexcel.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from datetime import datetime
+from typing import Any
 
 import fastexcel
 import pandas as pd
@@ -492,72 +495,19 @@ def test_sheet_with_ref():
 
 
 @pytest.mark.parametrize("excel_file", ["sheet-null-strings.xlsx", "sheet-null-strings-empty.xlsx"])
-def test_null_strings(excel_file: str):
+def test_null_strings(excel_file: str, expected_data_sheet_null_strings: dict[str, list[Any]]):
     excel_reader = fastexcel.read_excel(path_for_fixture(excel_file))
     sheet = excel_reader.load_sheet(0)
 
     assert sheet.height == sheet.total_height == 10
     assert sheet.width == 6
 
-    expected = {
-        "FIRST_LABEL": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
-        "SECOND_LABEL": ["AA", "BB", "CC", "DD", "EE", "FF", "GG", "HH", "II", "JJ"],
-        "DATES_AND_NULLS": [
-            None,
-            None,
-            None,
-            datetime(2022, 12, 19, 0, 0),
-            datetime(2022, 8, 26, 0, 0),
-            datetime(2023, 5, 6, 0, 0),
-            datetime(2023, 3, 20, 0, 0),
-            datetime(2022, 8, 29, 0, 0),
-            None,
-            None,
-        ],
-        "TIMESTAMPS_AND_NULLS": [
-            None,
-            None,
-            datetime(2023, 2, 18, 6, 13, 56, 730000),
-            datetime(2022, 9, 20, 20, 0, 7, 50000),
-            datetime(2022, 9, 24, 17, 4, 31, 236000),
-            None,
-            None,
-            None,
-            datetime(2022, 9, 14, 1, 50, 58, 390000),
-            datetime(2022, 10, 21, 17, 20, 12, 223000),
-        ],
-        "INTS_AND_NULLS": [
-            2076.0,
-            2285.0,
-            39323.0,
-            None,
-            None,
-            None,
-            11953.0,
-            None,
-            30192.0,
-            None,
-        ],
-        "FLOATS_AND_NULLS": [
-            141.02023312814603,
-            778.0655928608671,
-            None,
-            497.60307287584106,
-            627.446112513911,
-            None,
-            None,
-            None,
-            488.3509486743364,
-            None,
-        ],
-    }
-
-    pd_df = pd.DataFrame(expected)
+    pd_df = pd.DataFrame(expected_data_sheet_null_strings)
     pd_df["DATES_AND_NULLS"] = pd_df["DATES_AND_NULLS"].dt.as_unit("ms")
     pd_df["TIMESTAMPS_AND_NULLS"] = pd_df["TIMESTAMPS_AND_NULLS"].dt.as_unit("ms")
     pd_assert_frame_equal(sheet.to_pandas(), pd_df)
 
-    pl_df = pl.DataFrame(expected).with_columns(
+    pl_df = pl.DataFrame(expected_data_sheet_null_strings).with_columns(
         pl.col("DATES_AND_NULLS").dt.cast_time_unit("ms"),
         pl.col("TIMESTAMPS_AND_NULLS").dt.cast_time_unit("ms"),
     )

--- a/src/types/python/excelreader.rs
+++ b/src/types/python/excelreader.rs
@@ -3,11 +3,7 @@ use std::{
     io::{BufReader, Cursor},
 };
 
-use arrow::{
-    datatypes::{Field, Schema},
-    pyarrow::ToPyArrow,
-    record_batch::RecordBatch,
-};
+use arrow::{pyarrow::ToPyArrow, record_batch::RecordBatch};
 use calamine::{
     open_workbook_auto, open_workbook_auto_from_rs, Data, DataRef, Range, Reader, Sheets,
 };
@@ -25,7 +21,7 @@ use crate::{
 
 use crate::utils::schema::get_schema_sample_rows;
 
-use super::excelsheet::record_batch_from_data_and_schema;
+use super::excelsheet::record_batch_from_data_and_columns;
 use super::excelsheet::{
     column_info::{build_available_columns, build_available_columns_info},
     sheet_data::ExcelSheetData,
@@ -138,14 +134,7 @@ impl ExcelReader {
 
         let final_columns = selected_columns.select_columns(&available_columns)?;
 
-        let fields = final_columns
-            .iter()
-            .map(Into::<Field>::into)
-            .collect::<Vec<_>>();
-
-        let schema = Schema::new(fields);
-
-        record_batch_from_data_and_schema(schema, data, offset, limit)
+        record_batch_from_data_and_columns(final_columns, data, offset, limit)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/types/python/excelsheet/column_info.rs
+++ b/src/types/python/excelsheet/column_info.rs
@@ -88,7 +88,7 @@ impl FromStr for DTypeFrom {
 pub(crate) struct ColumnInfo {
     /// `str`. The name of the column
     #[pyo3(get)]
-    name: String,
+    pub name: String,
     /// `int`. The index of the column
     #[pyo3(get)]
     index: usize,


### PR DESCRIPTION
Fix an inconsistency in column ordering when loading a sheet eagerly. I guess this occured because the ager loading PR stood open for so long that the refactoring on column metadata was done in the meantime, and wasn't properly taken into account when updating the eagerness branch