### PR TITLE
fix(ci): replace macos-latest with macos-13

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-13", "windows-latest"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -117,7 +117,7 @@ jobs:
         # Only testing the build on the smallest supported Python version
         # since we're building abi3 wheels
         python-version: ["3.8"]
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-13", "windows-latest"]
         architecture: [x86-64, aarch64]
         exclude:
           - os: windows-latest
@@ -128,7 +128,7 @@ jobs:
       if: matrix.architecture == 'aarch64'
       id: target
       run: |
-        TARGET=${{ matrix.os == 'macos-latest' && 'aarch64-apple-darwin' || 'aarch64-unknown-linux-gnu'}}
+        TARGET=${{ matrix.os == 'macos-13' && 'aarch64-apple-darwin' || 'aarch64-unknown-linux-gnu'}}
         echo "target=$TARGET" >> $GITHUB_OUTPUT
 
     - name: build (fast)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         path: dist
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
         python-version: ["3.8"]


### PR DESCRIPTION
It seems like `macos-latest` runners do not provide `aarch64` anymore. I checked the release artifacts, and they're not built for for `x86_64` anymore (see articafts of https://github.com/ToucanToco/fastexcel/actions/runs/10038787833 and  https://pypi.org/project/fastexcel/#files ). This should hopefully fix it 