### PR TITLE
fix(ci): fix interpreter used by maturin

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -141,5 +141,5 @@ jobs:
       with:
         manylinux: auto
         command: build
-        args: "-o dist --interpreter python${{ matrix.python-version }}"
+        args: "-o dist"
         target: ${{ steps.target.outputs.target }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,10 +117,15 @@ jobs:
         # Only testing the build on the smallest supported Python version
         # since we're building abi3 wheels
         python-version: ["3.8"]
-        os: ["ubuntu-latest", "macos-13", "windows-latest"]
+        os: ["ubuntu-latest", "macos-12", "macos-13", "windows-latest"]
         architecture: [x86-64, aarch64]
         exclude:
           - os: windows-latest
+            architecture: aarch64
+          # Using macOS 13 for arm wheels and macOS 12 for x86_64
+          - os: macos-13
+            architecture: x86-64
+          - os: macos-12
             architecture: aarch64
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,15 +117,10 @@ jobs:
         # Only testing the build on the smallest supported Python version
         # since we're building abi3 wheels
         python-version: ["3.8"]
-        os: ["ubuntu-latest", "macos-12", "macos-13", "windows-latest"]
+        os: ["ubuntu-latest", "macos-13", "windows-latest"]
         architecture: [x86-64, aarch64]
         exclude:
           - os: windows-latest
-            architecture: aarch64
-          # Using macOS 13 for arm wheels and macOS 12 for x86_64
-          - os: macos-13
-            architecture: x86-64
-          - os: macos-12
             architecture: aarch64
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         manylinux: auto
         command: build
-        args: "--release -o dist --interpreter python${{ matrix.python-version }}"
+        args: "--release -o dist"
         target: ${{ matrix.architecture == 'aarch64' && 'aarch64-unknown-linux-gnu' || null }}
     - name: Upload wheels
       uses: actions/upload-artifact@v4
@@ -40,7 +40,7 @@ jobs:
       uses: messense/maturin-action@v1
       with:
         command: build
-        args: "--release -o dist --interpreter python${{ matrix.python-version }}"
+        args: "--release -o dist"
         target: x86_64
     - name: Upload wheels
       uses: actions/upload-artifact@v4
@@ -60,7 +60,7 @@ jobs:
       uses: messense/maturin-action@v1
       with:
         command: build
-        args: "--release -o dist --interpreter python${{ matrix.python-version }}"
+        args: "--release -o dist"
         target: aarch64
     - name: Upload wheels
       uses: actions/upload-artifact@v4
@@ -80,7 +80,7 @@ jobs:
       uses: messense/maturin-action@v1
       with:
         command: build
-        args: "--release -o dist --interpreter python${{ matrix.python-version }}"
+        args: "--release -o dist"
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,12 @@ jobs:
         name: "wheels-linux-python-${{ matrix.python-version }}-${{ matrix.architecture }}"
         path: dist
 
-  macos:
-    runs-on: macos-13
+  macos-x86-64:
+    runs-on: macos-12
     strategy:
       matrix:
         python-version: ["3.8"]
-        architecture: [x86-64, aarch64]
+        architecture: [x86-64]
     steps:
     - uses: actions/checkout@v4
     - name: build (release)
@@ -41,7 +41,27 @@ jobs:
       with:
         command: build
         args: "--release -o dist --interpreter python${{ matrix.python-version }}"
-        target: ${{ matrix.architecture == 'aarch64' && 'aarch64-apple-darwin' || null }}
+        target: x86_64
+    - name: Upload wheels
+      uses: actions/upload-artifact@v4
+      with:
+        name: "wheels-macos-python-${{ matrix.python-version }}-${{ matrix.architecture }}"
+        path: dist
+
+  macos-aarch64:
+    runs-on: macos-13
+    strategy:
+      matrix:
+        python-version: ["3.8"]
+        architecture: [aarch64]
+    steps:
+    - uses: actions/checkout@v4
+    - name: build (release)
+      uses: messense/maturin-action@v1
+      with:
+        command: build
+        args: "--release -o dist --interpreter python${{ matrix.python-version }}"
+        target: aarch64
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,32 +28,12 @@ jobs:
         name: "wheels-linux-python-${{ matrix.python-version }}-${{ matrix.architecture }}"
         path: dist
 
-  macos-x86-64:
-    runs-on: macos-12
-    strategy:
-      matrix:
-        python-version: ["3.8"]
-        architecture: [x86-64]
-    steps:
-    - uses: actions/checkout@v4
-    - name: build (release)
-      uses: messense/maturin-action@v1
-      with:
-        command: build
-        args: "--release -o dist"
-        target: x86_64
-    - name: Upload wheels
-      uses: actions/upload-artifact@v4
-      with:
-        name: "wheels-macos-python-${{ matrix.python-version }}-${{ matrix.architecture }}"
-        path: dist
-
-  macos-aarch64:
+  macos:
     runs-on: macos-13
     strategy:
       matrix:
         python-version: ["3.8"]
-        architecture: [aarch64]
+        architecture: [x86-64, aarch64]
     steps:
     - uses: actions/checkout@v4
     - name: build (release)
@@ -61,7 +41,7 @@ jobs:
       with:
         command: build
         args: "--release -o dist"
-        target: aarch64
+        target: ${{ matrix.architecture == 'aarch64' && 'aarch64-apple-darwin' || null }}
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
weirdly, maturin interprets `python3.8` as `pypy` on macos. Without specifying the interpreter, we get an ABI3 wheel, as expected