### PR TITLE
feat!(excelreader): only load dtypes for columns specified via `use_columns`

### DIFF
--- a/python/fastexcel/__init__.py
+++ b/python/fastexcel/__init__.py
@@ -82,10 +82,9 @@ class ExcelSheet:
         """The sheet's selected columns"""
         return self._sheet.selected_columns
 
-    @property
     def available_columns(self) -> list[ColumnInfo]:
         """The columns available for the given sheet"""
-        return self._sheet.available_columns
+        return self._sheet.available_columns()
 
     @property
     def specified_dtypes(self) -> DTypeMap | None:

--- a/python/fastexcel/__init__.py
+++ b/python/fastexcel/__init__.py
@@ -24,6 +24,7 @@ from ._fastexcel import (
     CalamineError,
     CannotRetrieveCellDataError,
     ColumnInfo,
+    ColumnInfoBuilder,
     ColumnNotFoundError,
     FastExcelError,
     InvalidParametersError,
@@ -160,10 +161,9 @@ class ExcelTable:
         """The table's selected columns"""
         return self._table.selected_columns
 
-    @property
     def available_columns(self) -> list[ColumnInfo]:
         """The columns available for the given table"""
-        return self._table.available_columns
+        return self._table.available_columns()
 
     @property
     def specified_dtypes(self) -> DTypeMap | None:
@@ -211,7 +211,11 @@ class ExcelReader:
         n_rows: int | None = None,
         schema_sample_rows: int | None = 1_000,
         dtype_coercion: Literal["coerce", "strict"] = "coerce",
-        use_columns: list[str] | list[int] | str | Callable[[ColumnInfo], bool] | None = None,
+        use_columns: list[str]
+        | list[int]
+        | str
+        | Callable[[ColumnInfoBuilder], bool]
+        | None = None,
         dtypes: DType | DTypeMap | None = None,
     ) -> ExcelSheet:
         """Loads a sheet lazily by index or name.
@@ -288,7 +292,11 @@ class ExcelReader:
         n_rows: int | None = None,
         schema_sample_rows: int | None = 1_000,
         dtype_coercion: Literal["coerce", "strict"] = "coerce",
-        use_columns: list[str] | list[int] | str | Callable[[ColumnInfo], bool] | None = None,
+        use_columns: list[str]
+        | list[int]
+        | str
+        | Callable[[ColumnInfoBuilder], bool]
+        | None = None,
         dtypes: DType | DTypeMap | None = None,
         eager: Literal[False] = ...,
     ) -> ExcelTable: ...
@@ -303,7 +311,11 @@ class ExcelReader:
         n_rows: int | None = None,
         schema_sample_rows: int | None = 1_000,
         dtype_coercion: Literal["coerce", "strict"] = "coerce",
-        use_columns: list[str] | list[int] | str | Callable[[ColumnInfo], bool] | None = None,
+        use_columns: list[str]
+        | list[int]
+        | str
+        | Callable[[ColumnInfoBuilder], bool]
+        | None = None,
         dtypes: DType | DTypeMap | None = None,
         eager: Literal[True] = ...,
     ) -> pa.RecordBatch: ...
@@ -317,7 +329,11 @@ class ExcelReader:
         n_rows: int | None = None,
         schema_sample_rows: int | None = 1_000,
         dtype_coercion: Literal["coerce", "strict"] = "coerce",
-        use_columns: list[str] | list[int] | str | Callable[[ColumnInfo], bool] | None = None,
+        use_columns: list[str]
+        | list[int]
+        | str
+        | Callable[[ColumnInfoBuilder], bool]
+        | None = None,
         dtypes: DType | DTypeMap | None = None,
         eager: bool = False,
     ) -> ExcelTable | pa.RecordBatch:
@@ -415,7 +431,11 @@ class ExcelReader:
         n_rows: int | None = None,
         schema_sample_rows: int | None = 1_000,
         dtype_coercion: Literal["coerce", "strict"] = "coerce",
-        use_columns: list[str] | list[int] | str | Callable[[ColumnInfo], bool] | None = None,
+        use_columns: list[str]
+        | list[int]
+        | str
+        | Callable[[ColumnInfoBuilder], bool]
+        | None = None,
         dtypes: DType | DTypeMap | None = None,
     ) -> ExcelSheet:
         """Loads a sheet by name.
@@ -444,7 +464,11 @@ class ExcelReader:
         n_rows: int | None = None,
         schema_sample_rows: int | None = 1_000,
         dtype_coercion: Literal["coerce", "strict"] = "coerce",
-        use_columns: list[str] | list[int] | str | Callable[[ColumnInfo], bool] | None = None,
+        use_columns: list[str]
+        | list[int]
+        | str
+        | Callable[[ColumnInfoBuilder], bool]
+        | None = None,
         dtypes: DType | DTypeMap | None = None,
     ) -> ExcelSheet:
         """Loads a sheet by index.

--- a/python/fastexcel/__init__.py
+++ b/python/fastexcel/__init__.py
@@ -24,7 +24,7 @@ from ._fastexcel import (
     CalamineError,
     CannotRetrieveCellDataError,
     ColumnInfo,
-    ColumnInfoBuilder,
+    ColumnInfoNoDtype,
     ColumnNotFoundError,
     FastExcelError,
     InvalidParametersError,
@@ -214,7 +214,7 @@ class ExcelReader:
         use_columns: list[str]
         | list[int]
         | str
-        | Callable[[ColumnInfoBuilder], bool]
+        | Callable[[ColumnInfoNoDtype], bool]
         | None = None,
         dtypes: DType | DTypeMap | None = None,
     ) -> ExcelSheet:
@@ -295,7 +295,7 @@ class ExcelReader:
         use_columns: list[str]
         | list[int]
         | str
-        | Callable[[ColumnInfoBuilder], bool]
+        | Callable[[ColumnInfoNoDtype], bool]
         | None = None,
         dtypes: DType | DTypeMap | None = None,
         eager: Literal[False] = ...,
@@ -314,7 +314,7 @@ class ExcelReader:
         use_columns: list[str]
         | list[int]
         | str
-        | Callable[[ColumnInfoBuilder], bool]
+        | Callable[[ColumnInfoNoDtype], bool]
         | None = None,
         dtypes: DType | DTypeMap | None = None,
         eager: Literal[True] = ...,
@@ -332,7 +332,7 @@ class ExcelReader:
         use_columns: list[str]
         | list[int]
         | str
-        | Callable[[ColumnInfoBuilder], bool]
+        | Callable[[ColumnInfoNoDtype], bool]
         | None = None,
         dtypes: DType | DTypeMap | None = None,
         eager: bool = False,
@@ -434,7 +434,7 @@ class ExcelReader:
         use_columns: list[str]
         | list[int]
         | str
-        | Callable[[ColumnInfoBuilder], bool]
+        | Callable[[ColumnInfoNoDtype], bool]
         | None = None,
         dtypes: DType | DTypeMap | None = None,
     ) -> ExcelSheet:
@@ -467,7 +467,7 @@ class ExcelReader:
         use_columns: list[str]
         | list[int]
         | str
-        | Callable[[ColumnInfoBuilder], bool]
+        | Callable[[ColumnInfoNoDtype], bool]
         | None = None,
         dtypes: DType | DTypeMap | None = None,
     ) -> ExcelSheet:

--- a/python/fastexcel/_fastexcel.pyi
+++ b/python/fastexcel/_fastexcel.pyi
@@ -11,6 +11,15 @@ ColumnNameFrom = Literal["provided", "looked_up", "generated"]
 DTypeFrom = Literal["provided_for_all", "provided_by_index", "provided_by_name", "guessed"]
 SheetVisible = Literal["visible", "hidden", "veryhidden"]
 
+class ColumnInfoBuilder:
+    def __init__(self, *, name: str, index: int, column_name_from: ColumnNameFrom) -> None: ...
+    @property
+    def name(self) -> str: ...
+    @property
+    def index(self) -> int: ...
+    @property
+    def column_name_from(self) -> ColumnNameFrom: ...
+
 class ColumnInfo:
     def __init__(
         self,
@@ -84,7 +93,6 @@ class _ExcelTable:
     @property
     def selected_columns(self) -> list[ColumnInfo]:
         """The table's selected columns"""
-    @property
     def available_columns(self) -> list[ColumnInfo]:
         """The columns available for the given table"""
     @property
@@ -107,7 +115,11 @@ class _ExcelReader:
         n_rows: int | None = None,
         schema_sample_rows: int | None = 1_000,
         dtype_coercion: Literal["coerce", "strict"] = "coerce",
-        use_columns: list[str] | list[int] | str | Callable[[ColumnInfo], bool] | None = None,
+        use_columns: list[str]
+        | list[int]
+        | str
+        | Callable[[ColumnInfoBuilder], bool]
+        | None = None,
         dtypes: DType | DTypeMap | None = None,
         eager: Literal[False] = ...,
     ) -> _ExcelSheet: ...
@@ -122,7 +134,11 @@ class _ExcelReader:
         n_rows: int | None = None,
         schema_sample_rows: int | None = 1_000,
         dtype_coercion: Literal["coerce", "strict"] = "coerce",
-        use_columns: list[str] | list[int] | str | None = None,
+        use_columns: list[str]
+        | list[int]
+        | str
+        | Callable[[ColumnInfoBuilder], bool]
+        | None = None,
         dtypes: DType | DTypeMap | None = None,
         eager: Literal[True] = ...,
     ) -> pa.RecordBatch: ...
@@ -137,7 +153,11 @@ class _ExcelReader:
         n_rows: int | None = None,
         schema_sample_rows: int | None = 1_000,
         dtype_coercion: Literal["coerce", "strict"] = "coerce",
-        use_columns: list[str] | list[int] | str | Callable[[ColumnInfo], bool] | None = None,
+        use_columns: list[str]
+        | list[int]
+        | str
+        | Callable[[ColumnInfoBuilder], bool]
+        | None = None,
         dtypes: DType | DTypeMap | None = None,
         eager: Literal[False] = ...,
     ) -> _ExcelTable: ...
@@ -152,7 +172,11 @@ class _ExcelReader:
         n_rows: int | None = None,
         schema_sample_rows: int | None = 1_000,
         dtype_coercion: Literal["coerce", "strict"] = "coerce",
-        use_columns: list[str] | list[int] | str | Callable[[ColumnInfo], bool] | None = None,
+        use_columns: list[str]
+        | list[int]
+        | str
+        | Callable[[ColumnInfoBuilder], bool]
+        | None = None,
         dtypes: DType | DTypeMap | None = None,
         eager: Literal[True] = ...,
     ) -> pa.RecordBatch: ...

--- a/python/fastexcel/_fastexcel.pyi
+++ b/python/fastexcel/_fastexcel.pyi
@@ -11,7 +11,7 @@ ColumnNameFrom = Literal["provided", "looked_up", "generated"]
 DTypeFrom = Literal["provided_for_all", "provided_by_index", "provided_by_name", "guessed"]
 SheetVisible = Literal["visible", "hidden", "veryhidden"]
 
-class ColumnInfoBuilder:
+class ColumnInfoNoDtype:
     def __init__(self, *, name: str, index: int, column_name_from: ColumnNameFrom) -> None: ...
     @property
     def name(self) -> str: ...
@@ -118,7 +118,7 @@ class _ExcelReader:
         use_columns: list[str]
         | list[int]
         | str
-        | Callable[[ColumnInfoBuilder], bool]
+        | Callable[[ColumnInfoNoDtype], bool]
         | None = None,
         dtypes: DType | DTypeMap | None = None,
         eager: Literal[False] = ...,
@@ -137,7 +137,7 @@ class _ExcelReader:
         use_columns: list[str]
         | list[int]
         | str
-        | Callable[[ColumnInfoBuilder], bool]
+        | Callable[[ColumnInfoNoDtype], bool]
         | None = None,
         dtypes: DType | DTypeMap | None = None,
         eager: Literal[True] = ...,
@@ -156,7 +156,7 @@ class _ExcelReader:
         use_columns: list[str]
         | list[int]
         | str
-        | Callable[[ColumnInfoBuilder], bool]
+        | Callable[[ColumnInfoNoDtype], bool]
         | None = None,
         dtypes: DType | DTypeMap | None = None,
         eager: Literal[False] = ...,
@@ -175,7 +175,7 @@ class _ExcelReader:
         use_columns: list[str]
         | list[int]
         | str
-        | Callable[[ColumnInfoBuilder], bool]
+        | Callable[[ColumnInfoNoDtype], bool]
         | None = None,
         dtypes: DType | DTypeMap | None = None,
         eager: Literal[True] = ...,

--- a/python/fastexcel/_fastexcel.pyi
+++ b/python/fastexcel/_fastexcel.pyi
@@ -51,7 +51,6 @@ class _ExcelSheet:
     @property
     def selected_columns(self) -> list[ColumnInfo]:
         """The sheet's selected columns"""
-    @property
     def available_columns(self) -> list[ColumnInfo]:
         """The columns available for the given sheet"""
     @property

--- a/python/tests/test_alias_generation.py
+++ b/python/tests/test_alias_generation.py
@@ -19,7 +19,7 @@ def test_alias_generation_with_use_columns(use_columns: list[str] | list[int] | 
     )
 
     sheet = excel_reader.load_sheet(0, use_columns=use_columns)
-    assert [col.name for col in sheet.available_columns] == ["col", "col_1", "col_2"]
+    assert [col.name for col in sheet.available_columns()] == ["col", "col_1", "col_2"]
 
     pd_assert_frame_equal(
         sheet.to_pandas(),

--- a/python/tests/test_column_selection.py
+++ b/python/tests/test_column_selection.py
@@ -39,7 +39,7 @@ def test_single_sheet_all_columns(
 
     sheet_explicit_arg = excel_reader_single_sheet.load_sheet(0, use_columns=None)
     assert sheet.selected_columns == expected_column_info
-    assert sheet.available_columns == expected_column_info
+    assert sheet.available_columns() == expected_column_info
 
     expected = {"Month": [1.0, 2.0], "Year": [2019.0, 2020.0]}
     expected_pd_df = pd.DataFrame(expected)
@@ -68,7 +68,7 @@ def test_single_sheet_subset_by_str(
         for idx, col in enumerate(["Month", "Year"]):
             sheet = excel_reader_single_sheet.load_sheet(sheet_name_or_idx, use_columns=[col])
             assert sheet.selected_columns == [expected_column_info[idx]]
-            assert sheet.available_columns == expected_column_info
+            assert sheet.available_columns() == expected_column_info
 
             pd_df = sheet.to_pandas()
             pd_assert_frame_equal(pd_df, pd.DataFrame({col: expected[col]}))
@@ -88,7 +88,7 @@ def test_single_sheet_subset_by_index(
         for idx, col_name in enumerate(["Month", "Year"]):
             sheet = excel_reader_single_sheet.load_sheet(sheet_name_or_idx, use_columns=[idx])
             assert sheet.selected_columns == [expected_column_info[idx]]
-            assert sheet.available_columns == expected_column_info
+            assert sheet.available_columns() == expected_column_info
 
             pd_df = sheet.to_pandas()
             pd_assert_frame_equal(pd_df, pd.DataFrame({col_name: expected[col_name]}))
@@ -161,7 +161,7 @@ def test_single_sheet_with_unnamed_columns(
         sheet_with_unnamed_columns_expected_column_info[2],
         sheet_with_unnamed_columns_expected_column_info[3],
     ]
-    assert sheet.available_columns == sheet_with_unnamed_columns_expected_column_info
+    assert sheet.available_columns() == sheet_with_unnamed_columns_expected_column_info
 
     pd_assert_frame_equal(sheet.to_pandas(), pd.DataFrame(expected))
     pl_assert_frame_equal(sheet.to_polars(), pl.DataFrame(expected))
@@ -174,7 +174,7 @@ def test_single_sheet_with_unnamed_columns(
         sheet_with_unnamed_columns_expected_column_info[2],
         sheet_with_unnamed_columns_expected_column_info[3],
     ]
-    assert sheet.available_columns == sheet_with_unnamed_columns_expected_column_info
+    assert sheet.available_columns() == sheet_with_unnamed_columns_expected_column_info
 
     pd_assert_frame_equal(sheet.to_pandas(), pd.DataFrame(expected))
     pl_assert_frame_equal(sheet.to_polars(), pl.DataFrame(expected))
@@ -198,7 +198,7 @@ def test_single_sheet_with_unnamed_columns_and_pagination(
     sheet = excel_reader_single_sheet_with_unnamed_columns.load_sheet(
         "With unnamed columns", use_columns=use_columns_str, n_rows=1
     )
-    assert sheet.available_columns == sheet_with_unnamed_columns_expected_column_info
+    assert sheet.available_columns() == sheet_with_unnamed_columns_expected_column_info
 
     pd_assert_frame_equal(sheet.to_pandas(), pd.DataFrame(expected))
     pl_assert_frame_equal(sheet.to_polars(), pl.DataFrame(expected))
@@ -206,7 +206,7 @@ def test_single_sheet_with_unnamed_columns_and_pagination(
     sheet = excel_reader_single_sheet_with_unnamed_columns.load_sheet(
         "With unnamed columns", use_columns=use_columns_idx, n_rows=1
     )
-    assert sheet.available_columns == sheet_with_unnamed_columns_expected_column_info
+    assert sheet.available_columns() == sheet_with_unnamed_columns_expected_column_info
 
     pd_assert_frame_equal(sheet.to_pandas(), pd.DataFrame(expected))
     pl_assert_frame_equal(sheet.to_polars(), pl.DataFrame(expected))
@@ -221,7 +221,7 @@ def test_single_sheet_with_unnamed_columns_and_pagination(
     sheet = excel_reader_single_sheet_with_unnamed_columns.load_sheet(
         "With unnamed columns", use_columns=use_columns_str, skip_rows=1
     )
-    assert sheet.available_columns == sheet_with_unnamed_columns_expected_column_info
+    assert sheet.available_columns() == sheet_with_unnamed_columns_expected_column_info
 
     pd_assert_frame_equal(sheet.to_pandas(), pd.DataFrame(expected))
     pl_assert_frame_equal(sheet.to_polars(), pl.DataFrame(expected))
@@ -229,7 +229,7 @@ def test_single_sheet_with_unnamed_columns_and_pagination(
     sheet = excel_reader_single_sheet_with_unnamed_columns.load_sheet(
         "With unnamed columns", use_columns=use_columns_idx, skip_rows=1
     )
-    assert sheet.available_columns == sheet_with_unnamed_columns_expected_column_info
+    assert sheet.available_columns() == sheet_with_unnamed_columns_expected_column_info
 
     pd_assert_frame_equal(sheet.to_pandas(), pd.DataFrame(expected))
     pl_assert_frame_equal(sheet.to_polars(), pl.DataFrame(expected))
@@ -263,7 +263,7 @@ def test_single_sheet_with_unnamed_columns_and_pagination_and_column_names(
     sheet = excel_reader_single_sheet_with_unnamed_columns.load_sheet(
         "With unnamed columns", use_columns=use_columns_idx, skip_rows=1, column_names=column_names
     )
-    assert [col.name for col in sheet.available_columns] == expected_columns_names
+    assert [col.name for col in sheet.available_columns()] == expected_columns_names
 
     pd_assert_frame_equal(sheet.to_pandas(), pd.DataFrame(expected))
     pl_assert_frame_equal(sheet.to_polars(), pl.DataFrame(expected))
@@ -274,7 +274,7 @@ def test_single_sheet_with_unnamed_columns_and_pagination_and_column_names(
     sheet = excel_reader_single_sheet_with_unnamed_columns.load_sheet(
         "With unnamed columns", use_columns=use_columns_idx, skip_rows=2, column_names=column_names
     )
-    assert [col.name for col in sheet.available_columns] == expected_columns_names
+    assert [col.name for col in sheet.available_columns()] == expected_columns_names
 
     pd_assert_frame_equal(sheet.to_pandas(), pd.DataFrame(expected_first_row_skipped))
     pl_assert_frame_equal(sheet.to_polars(), pl.DataFrame(expected_first_row_skipped))
@@ -298,7 +298,7 @@ def test_single_sheet_with_unnamed_columns_and_str_range(
         sheet_with_unnamed_columns_expected_column_info[:1]
         + sheet_with_unnamed_columns_expected_column_info[2:]
     )
-    assert sheet.available_columns == sheet_with_unnamed_columns_expected_column_info
+    assert sheet.available_columns() == sheet_with_unnamed_columns_expected_column_info
     pd_assert_frame_equal(sheet.to_pandas(), pd.DataFrame(expected))
     pl_assert_frame_equal(sheet.to_polars(), pl.DataFrame(expected))
 
@@ -360,7 +360,7 @@ def test_use_columns_with_column_names() -> None:
         column_names=["bools_renamed", "dates_renamed"],
     )
 
-    assert sheet.available_columns == [
+    assert sheet.available_columns() == [
         fastexcel.ColumnInfo(
             name="__UNNAMED__0",
             column_name_from="generated",
@@ -420,7 +420,7 @@ def test_use_columns_with_callable() -> None:
 
     sheet = excel_reader.load_sheet(2)
     assert (
-        [(c.name, c.dtype) for c in sheet.available_columns]
+        [(c.name, c.dtype) for c in sheet.available_columns()]
         == [(c.name, c.dtype) for c in sheet.selected_columns]
         == [
             ("col1", "float"),

--- a/python/tests/test_column_selection.py
+++ b/python/tests/test_column_selection.py
@@ -450,15 +450,6 @@ def test_use_columns_with_callable() -> None:
         ("__UNNAMED__3", "float"),
     ]
 
-    sheet = excel_reader.load_sheet(
-        2,
-        use_columns=lambda col: col.dtype == "string",
-    )
-    assert [(c.name, c.dtype) for c in sheet.selected_columns] == [
-        ("col3", "string"),
-        ("col5", "string"),
-    ]
-
 
 def test_use_columns_with_bad_callable() -> None:
     excel_reader = fastexcel.read_excel(path_for_fixture("fixture-multi-sheet.xlsx"))

--- a/python/tests/test_dtypes.py
+++ b/python/tests/test_dtypes.py
@@ -10,6 +10,7 @@ import polars as pl
 import pytest
 from pandas.testing import assert_frame_equal as pd_assert_frame_equal
 from polars.testing import assert_frame_equal as pl_assert_frame_equal
+from pytest_mock import MockerFixture
 
 from utils import path_for_fixture
 
@@ -262,7 +263,7 @@ def test_dtype_coercion_behavior__strict_sampling_limit(eager: bool) -> None:
 def test_one_dtype_for_all() -> None:
     excel_reader = fastexcel.read_excel(path_for_fixture("fixture-multi-dtypes-columns.xlsx"))
     sheet = excel_reader.load_sheet(0, dtypes="string")
-    assert sheet.available_columns == [
+    assert sheet.available_columns() == [
         fastexcel.ColumnInfo(
             name="Employee ID",
             index=0,
@@ -316,7 +317,7 @@ def test_one_dtype_for_all() -> None:
     assert sheet.to_polars().dtypes == [pl.String] * 7
 
 
-def test_fallback_infer_dtypes(mocker) -> None:
+def test_fallback_infer_dtypes(mocker: MockerFixture) -> None:
     """it should fallback to string if it can't infer the dtype"""
     import logging
 
@@ -336,7 +337,7 @@ def test_fallback_infer_dtypes(mocker) -> None:
         mocker.ANY,
     )
 
-    assert sheet.available_columns == [
+    assert sheet.available_columns() == [
         fastexcel.ColumnInfo(
             name="id",
             index=0,

--- a/python/tests/test_tables.py
+++ b/python/tests/test_tables.py
@@ -38,7 +38,7 @@ def test_load_table(path: str) -> None:
     assert users_tbl.name == "users"
     assert users_tbl.sheet_name == "sheet1"
     assert users_tbl.specified_dtypes is None
-    assert users_tbl.available_columns == [
+    assert users_tbl.available_columns() == [
         fastexcel.ColumnInfo(
             name="User Id",
             index=0,

--- a/src/data.rs
+++ b/src/data.rs
@@ -14,6 +14,7 @@ use crate::{
     },
 };
 
+#[derive(Debug)]
 pub(crate) enum ExcelSheetData<'r> {
     Owned(Range<CalData>),
     Ref(Range<CalDataRef<'r>>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod utils;
 use error::{py_errors, ErrorContext};
 use pyo3::prelude::*;
 use types::python::{
-    excelsheet::column_info::{ColumnInfo, ColumnInfoBuilder},
+    excelsheet::column_info::{ColumnInfo, ColumnInfoNoDtype},
     table::ExcelTable,
     ExcelReader, ExcelSheet,
 };
@@ -50,7 +50,7 @@ fn _fastexcel(m: &Bound<'_, PyModule>) -> PyResult<()> {
     let py = m.py();
     m.add_function(wrap_pyfunction!(read_excel, m)?)?;
     m.add_class::<ColumnInfo>()?;
-    m.add_class::<ColumnInfoBuilder>()?;
+    m.add_class::<ColumnInfoNoDtype>()?;
     m.add_class::<ExcelSheet>()?;
     m.add_class::<ExcelReader>()?;
     m.add_class::<ExcelTable>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@ mod utils;
 use error::{py_errors, ErrorContext};
 use pyo3::prelude::*;
 use types::python::{
-    excelsheet::column_info::ColumnInfo, table::ExcelTable, ExcelReader, ExcelSheet,
+    excelsheet::column_info::{ColumnInfo, ColumnInfoBuilder},
+    table::ExcelTable,
+    ExcelReader, ExcelSheet,
 };
 
 /// Reads an excel file and returns an object allowing to access its sheets and a bit of metadata
@@ -48,6 +50,7 @@ fn _fastexcel(m: &Bound<'_, PyModule>) -> PyResult<()> {
     let py = m.py();
     m.add_function(wrap_pyfunction!(read_excel, m)?)?;
     m.add_class::<ColumnInfo>()?;
+    m.add_class::<ColumnInfoBuilder>()?;
     m.add_class::<ExcelSheet>()?;
     m.add_class::<ExcelReader>()?;
     m.add_class::<ExcelTable>()?;

--- a/src/types/python/excelreader.rs
+++ b/src/types/python/excelreader.rs
@@ -288,7 +288,7 @@ impl ExcelReader {
         .into_pyresult()?;
 
         if eager {
-            excel_table.to_arrow(py).map(|py_obj| py_obj.into_bound(py))
+            Ok(excel_table.to_arrow(py)?.into_bound(py))
         } else {
             excel_table.into_bound_py_any(py)
         }

--- a/src/types/python/excelreader.rs
+++ b/src/types/python/excelreader.rs
@@ -27,7 +27,7 @@ use crate::{
 use pyo3::types::PyString;
 
 use super::excelsheet::{
-    column_info::{build_available_columns, build_available_columns_info},
+    column_info::{build_available_columns_info, finalize_column_info},
     ExcelSheet, Header, Pagination, SelectedColumns,
 };
 use super::table::ExcelTable;
@@ -156,9 +156,10 @@ impl ExcelReader {
 
         let sample_rows_limit = get_schema_sample_rows(sample_rows, offset, limit);
         let available_columns_info = build_available_columns_info(data, selected_columns, &header)?;
+        let final_columns_info = selected_columns.select_columns(available_columns_info)?;
 
-        let available_columns = build_available_columns(
-            available_columns_info,
+        let available_columns = finalize_column_info(
+            final_columns_info,
             data,
             offset,
             sample_rows_limit,
@@ -166,9 +167,7 @@ impl ExcelReader {
             dtype_coercion,
         )?;
 
-        let final_columns = selected_columns.select_columns(&available_columns)?;
-
-        record_batch_from_data_and_columns(&final_columns, data, offset, limit)
+        record_batch_from_data_and_columns(&available_columns, data, offset, limit)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/types/python/excelsheet/mod.rs
+++ b/src/types/python/excelsheet/mod.rs
@@ -2,7 +2,7 @@ pub(crate) mod column_info;
 pub(crate) mod table;
 
 use calamine::{CellType, Range, Sheet as CalamineSheet, SheetVisible as CalamineSheetVisible};
-use column_info::{AvailableColumns, ColumnInfoBuilder};
+use column_info::{AvailableColumns, ColumnInfoNoDtype};
 use std::{cmp, collections::HashSet, fmt::Debug, str::FromStr};
 
 use arrow::{pyarrow::ToPyArrow, record_batch::RecordBatch};
@@ -138,8 +138,8 @@ impl PartialEq for SelectedColumns {
 impl SelectedColumns {
     pub(super) fn select_columns(
         &self,
-        available_columns: Vec<ColumnInfoBuilder>,
-    ) -> FastExcelResult<Vec<ColumnInfoBuilder>> {
+        available_columns: Vec<ColumnInfoNoDtype>,
+    ) -> FastExcelResult<Vec<ColumnInfoNoDtype>> {
         match self {
             SelectedColumns::All => Ok(available_columns),
             SelectedColumns::Selection(selection) => {
@@ -164,7 +164,7 @@ impl SelectedColumns {
                 // We need to sort `available_columns` based on the order of the provided selection.
                 // First, we associated every element in the Vec with its position in the selection,
                 // and we filter out unselected columns
-                let mut cols: Vec<(usize, ColumnInfoBuilder)> = available_columns
+                let mut cols: Vec<(usize, ColumnInfoNoDtype)> = available_columns
                     .into_iter()
                     .enumerate()
                     .filter_map(|(idx, elem)| {

--- a/src/types/python/excelsheet/mod.rs
+++ b/src/types/python/excelsheet/mod.rs
@@ -323,15 +323,17 @@ impl<'py> IntoPyObject<'py> for &SheetVisible {
 
     type Output = Bound<'py, Self::Target>;
 
-    type Error = std::convert::Infallible;
+    type Error = FastExcelError;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        match self.0 {
-            CalamineSheetVisible::Visible => "visible",
-            CalamineSheetVisible::Hidden => "hidden",
-            CalamineSheetVisible::VeryHidden => "veryhidden",
-        }
-        .into_pyobject(py)
+        Ok(PyString::new(
+            py,
+            match self.0 {
+                CalamineSheetVisible::Visible => "visible",
+                CalamineSheetVisible::Hidden => "hidden",
+                CalamineSheetVisible::VeryHidden => "veryhidden",
+            },
+        ))
     }
 }
 
@@ -494,7 +496,7 @@ impl ExcelSheet {
     }
 
     #[getter]
-    pub fn visible<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyString>> {
+    pub fn visible<'py>(&'py self, py: Python<'py>) -> FastExcelResult<Bound<'py, PyString>> {
         let visible: SheetVisible = self.sheet_meta.visible.into();
         (&visible).into_pyobject(py).map_err(Into::into)
     }

--- a/src/types/python/excelsheet/mod.rs
+++ b/src/types/python/excelsheet/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod column_info;
 pub(crate) mod table;
 
 use calamine::{CellType, Range, Sheet as CalamineSheet, SheetVisible as CalamineSheetVisible};
+use column_info::{AvailableColumns, ColumnInfoBuilder};
 use std::{cmp, collections::HashSet, fmt::Debug, str::FromStr};
 
 use arrow::{pyarrow::ToPyArrow, record_batch::RecordBatch};
@@ -21,7 +22,7 @@ use crate::{
 };
 use crate::{types::dtype::DTypeCoercion, utils::schema::get_schema_sample_rows};
 
-use self::column_info::{build_available_columns, build_available_columns_info, ColumnInfo};
+use self::column_info::{build_available_columns_info, finalize_column_info, ColumnInfo};
 
 #[derive(Debug)]
 pub(crate) enum Header {
@@ -137,46 +138,68 @@ impl PartialEq for SelectedColumns {
 impl SelectedColumns {
     pub(super) fn select_columns(
         &self,
-        available_columns: &[ColumnInfo],
-    ) -> FastExcelResult<Vec<ColumnInfo>> {
+        available_columns: Vec<ColumnInfoBuilder>,
+    ) -> FastExcelResult<Vec<ColumnInfoBuilder>> {
         match self {
-            SelectedColumns::All => Ok(available_columns.to_vec()),
-            SelectedColumns::Selection(selection) => selection
-                .iter()
-                .map(|selected_column| {
-                    match selected_column {
-                        IdxOrName::Idx(index) => available_columns
-                            .iter()
-                            .find(|col_info| &col_info.index() == index),
-                        IdxOrName::Name(name) => available_columns
-                            .iter()
-                            .find(|col_info| col_info.name() == name.as_str()),
-                    }
-                    .ok_or_else(|| {
-                        FastExcelErrorKind::ColumnNotFound(selected_column.clone()).into()
-                    })
-                    .cloned()
-                    .with_context(|| format!("available columns are: {available_columns:?}"))
-                })
-                .collect(),
-            SelectedColumns::DynamicSelection(use_col_func) => Python::with_gil(|py| {
-                Ok(available_columns
+            SelectedColumns::All => Ok(available_columns),
+            SelectedColumns::Selection(selection) => {
+                let selected_indices: Vec<usize> = selection
                     .iter()
+                    .map(|selected_column| {
+                        match selected_column {
+                            IdxOrName::Idx(index) => available_columns
+                                .iter()
+                                .position(|col_info| &col_info.index() == index),
+                            IdxOrName::Name(name) => available_columns
+                                .iter()
+                                .position(|col_info| col_info.name() == name.as_str()),
+                        }
+                        .ok_or_else(|| {
+                            FastExcelErrorKind::ColumnNotFound(selected_column.clone()).into()
+                        })
+                        .with_context(|| format!("available columns are: {available_columns:?}"))
+                    })
+                    .collect::<FastExcelResult<_>>()?;
+
+                // We need to sort `available_columns` based on the order of the provided selection.
+                // First, we associated every element in the Vec with its position in the selection,
+                // and we filter out unselected columns
+                let mut cols: Vec<(usize, ColumnInfoBuilder)> = available_columns
+                    .into_iter()
+                    .enumerate()
+                    .filter_map(|(idx, elem)| {
+                        selected_indices
+                            .iter()
+                            .position(|selected_idx| *selected_idx == idx)
+                            .map(|position| (position, elem))
+                    })
+                    .collect();
+                // Then, we sort the columns based on their position in the selection
+                cols.sort_by_key(|(pos, _elem)| *pos);
+
+                // And finally, we drop the positions
+                Ok(cols.into_iter().map(|(_pos, elem)| elem).collect())
+            }
+            SelectedColumns::DynamicSelection(use_col_func) => Python::with_gil(|py| {
+                available_columns
+                    .into_iter()
                     .filter_map(
                         |col_info| match use_col_func.call1(py, (col_info.clone(),)) {
                             Err(err) => Some(Err(FastExcelErrorKind::InvalidParameters(format!(
                                 "`use_columns` callable could not be called ({err})"
-                            )))),
+                            ))
+                            .into())),
                             Ok(should_use_col) => match should_use_col.extract::<bool>(py) {
                                 Err(_) => Some(Err(FastExcelErrorKind::InvalidParameters(
                                     "`use_columns` callable should return a boolean".to_string(),
-                                ))),
-                                Ok(true) => Some(Ok(col_info.clone())),
+                                )
+                                .into())),
+                                Ok(true) => Some(Ok(col_info)),
                                 Ok(false) => None,
                             },
                         },
                     )
-                    .collect::<Result<Vec<_>, _>>()?)
+                    .collect()
             }),
         }
     }
@@ -355,7 +378,7 @@ pub(crate) struct ExcelSheet {
     schema_sample_rows: Option<usize>,
     dtype_coercion: DTypeCoercion,
     selected_columns: Vec<ColumnInfo>,
-    available_columns: Vec<ColumnInfo>,
+    available_columns: AvailableColumns,
     dtypes: Option<DTypes>,
 }
 
@@ -377,6 +400,8 @@ impl ExcelSheet {
     ) -> FastExcelResult<Self> {
         let available_columns_info =
             build_available_columns_info(&data, &selected_columns, &header)?;
+        let selected_columns_info = selected_columns.select_columns(available_columns_info)?;
+
         let mut sheet = ExcelSheet {
             sheet_meta,
             header,
@@ -388,16 +413,15 @@ impl ExcelSheet {
             height: None,
             total_height: None,
             width: None,
-            // Empty vecs as they'll be replaced
-            available_columns: Vec::with_capacity(0),
+            available_columns: AvailableColumns::Pending(selected_columns),
+            // Empty vec as It'll be replaced
             selected_columns: Vec::with_capacity(0),
         };
 
+        // Finalizing column info (figure out dtypes for every column)
         let row_limit = sheet.schema_sample_rows();
-
-        // Finalizing column info
-        let available_columns = build_available_columns(
-            available_columns_info,
+        let selected_columns = finalize_column_info(
+            selected_columns_info,
             &sheet.data,
             sheet.offset(),
             row_limit,
@@ -405,12 +429,36 @@ impl ExcelSheet {
             &sheet.dtype_coercion,
         )?;
 
-        // Figure out dtype for every column
-        let selected_columns = selected_columns.select_columns(&available_columns)?;
-        sheet.available_columns = available_columns;
         sheet.selected_columns = selected_columns;
 
         Ok(sheet)
+    }
+
+    fn ensure_available_columns_loaded(&mut self) -> FastExcelResult<()> {
+        let available_columns = match &self.available_columns {
+            AvailableColumns::Pending(selected_columns) => {
+                let available_columns_info =
+                    build_available_columns_info(&self.data, selected_columns, &self.header)?;
+                let final_info = finalize_column_info(
+                    available_columns_info,
+                    self.data(),
+                    self.offset(),
+                    self.limit(),
+                    self.dtypes.as_ref(),
+                    &self.dtype_coercion,
+                )?;
+                AvailableColumns::Loaded(final_info)
+            }
+            AvailableColumns::Loaded(_) => return Ok(()),
+        };
+
+        self.available_columns = available_columns;
+        Ok(())
+    }
+
+    fn load_available_columns(&mut self) -> FastExcelResult<&[ColumnInfo]> {
+        self.ensure_available_columns_loaded()?;
+        self.available_columns.as_loaded()
     }
 
     pub(crate) fn limit(&self) -> usize {
@@ -481,8 +529,11 @@ impl ExcelSheet {
         self.selected_columns.clone()
     }
 
-    pub fn available_columns<'p>(&'p self, _py: Python<'p>) -> Vec<ColumnInfo> {
-        self.available_columns.clone()
+    pub fn available_columns<'p>(
+        &'p mut self,
+        _py: Python<'p>,
+    ) -> FastExcelResult<Vec<ColumnInfo>> {
+        self.load_available_columns().map(|cols| cols.to_vec())
     }
 
     #[getter]

--- a/src/types/python/excelsheet/mod.rs
+++ b/src/types/python/excelsheet/mod.rs
@@ -479,7 +479,6 @@ impl ExcelSheet {
         self.selected_columns.clone()
     }
 
-    #[getter]
     pub fn available_columns<'p>(&'p self, _py: Python<'p>) -> Vec<ColumnInfo> {
         self.available_columns.clone()
     }

--- a/src/types/python/table.rs
+++ b/src/types/python/table.rs
@@ -17,13 +17,13 @@ use crate::{
     error::{ErrorContext, FastExcelError, FastExcelErrorKind, FastExcelResult},
     types::{
         dtype::{DType, DTypeCoercion, DTypes},
-        python::excelsheet::column_info::build_available_columns,
+        python::excelsheet::column_info::finalize_column_info,
     },
     utils::schema::get_schema_sample_rows,
 };
 
 use super::excelsheet::{
-    column_info::{build_available_columns_info, ColumnInfo},
+    column_info::{build_available_columns_info, AvailableColumns, ColumnInfo},
     Header, Pagination, SelectedColumns,
 };
 
@@ -34,7 +34,7 @@ pub(crate) struct ExcelTable {
     #[pyo3(get)]
     sheet_name: String,
     selected_columns: Vec<ColumnInfo>,
-    available_columns: Vec<ColumnInfo>,
+    available_columns: AvailableColumns,
     table: Table<Data>,
     header: Header,
     pagination: Pagination,
@@ -57,12 +57,13 @@ impl ExcelTable {
     ) -> FastExcelResult<Self> {
         let available_columns_info =
             build_available_columns_info(table.data(), &selected_columns, &header)?;
+        let selected_columns_info = selected_columns.select_columns(available_columns_info)?;
 
         let mut excel_table = ExcelTable {
             name: table.name().to_owned(),
             sheet_name: table.sheet_name().to_owned(),
-            // Empty vecs as they'll be replaced
-            available_columns: Vec::with_capacity(0),
+            available_columns: AvailableColumns::Pending(selected_columns),
+            // Empty vec as it'll be replaced
             selected_columns: Vec::with_capacity(0),
             table,
             header,
@@ -81,8 +82,8 @@ impl ExcelTable {
         );
 
         // Finalizing column info
-        let available_columns = build_available_columns(
-            available_columns_info,
+        let selected_columns = finalize_column_info(
+            selected_columns_info,
             excel_table.data(),
             excel_table.offset(),
             row_limit,
@@ -91,8 +92,6 @@ impl ExcelTable {
         )?;
 
         // Figure out dtype for every column
-        let selected_columns = selected_columns.select_columns(&available_columns)?;
-        excel_table.available_columns = available_columns;
         excel_table.selected_columns = selected_columns;
 
         Ok(excel_table)
@@ -100,6 +99,36 @@ impl ExcelTable {
 
     pub(crate) fn data(&self) -> &Range<Data> {
         self.table.data()
+    }
+
+    fn ensure_available_columns_loaded(&mut self) -> FastExcelResult<()> {
+        let available_columns = match &self.available_columns {
+            AvailableColumns::Pending(selected_columns) => {
+                let available_columns_info = build_available_columns_info(
+                    self.table.data(),
+                    selected_columns,
+                    &self.header,
+                )?;
+                let final_info = finalize_column_info(
+                    available_columns_info,
+                    self.data(),
+                    self.offset(),
+                    self.limit(),
+                    self.dtypes.as_ref(),
+                    &self.dtype_coercion,
+                )?;
+                AvailableColumns::Loaded(final_info)
+            }
+            AvailableColumns::Loaded(_) => return Ok(()),
+        };
+
+        self.available_columns = available_columns;
+        Ok(())
+    }
+
+    fn load_available_columns(&mut self) -> FastExcelResult<&[ColumnInfo]> {
+        self.ensure_available_columns_loaded()?;
+        self.available_columns.as_loaded()
     }
 }
 
@@ -198,9 +227,11 @@ impl ExcelTable {
         self.selected_columns.clone()
     }
 
-    #[getter]
-    pub fn available_columns(&self) -> Vec<ColumnInfo> {
-        self.available_columns.clone()
+    pub fn available_columns<'p>(
+        &'p mut self,
+        _py: Python<'p>,
+    ) -> FastExcelResult<Vec<ColumnInfo>> {
+        self.load_available_columns().map(|cols| cols.to_vec())
     }
 
     #[getter]

--- a/src/types/python/table.rs
+++ b/src/types/python/table.rs
@@ -5,7 +5,7 @@ use arrow::{
     pyarrow::ToPyArrow,
 };
 use calamine::{Data, Range, Table};
-use pyo3::{pyclass, pymethods, PyObject, PyResult, Python};
+use pyo3::{pyclass, pymethods, PyObject, Python};
 
 use crate::{
     data::{
@@ -14,9 +14,7 @@ use crate::{
         create_float_array_from_range, create_int_array_from_range, create_string_array_from_range,
         record_batch_from_name_array_iterator, selected_columns_to_schema,
     },
-    error::{
-        py_errors::IntoPyResult, ErrorContext, FastExcelError, FastExcelErrorKind, FastExcelResult,
-    },
+    error::{ErrorContext, FastExcelError, FastExcelErrorKind, FastExcelResult},
     types::{
         dtype::{DType, DTypeCoercion, DTypes},
         python::excelsheet::column_info::build_available_columns,
@@ -237,7 +235,7 @@ impl ExcelTable {
         })
     }
 
-    pub fn to_arrow(&self, py: Python<'_>) -> PyResult<PyObject> {
+    pub fn to_arrow(&self, py: Python<'_>) -> FastExcelResult<PyObject> {
         RecordBatch::try_from(self)
             .with_context(|| {
                 format!(
@@ -255,7 +253,6 @@ impl ExcelTable {
                     table = self.name, sheet = self.sheet_name
                 )
             })
-            .into_pyresult()
     }
 
     pub fn __repr__(&self) -> String {


### PR DESCRIPTION
This changes our logic regarding the information we extract on sheet load. Rather than loading dtype information for all available columns, we only load it for selected columns. This introduces two breaking changes:

* For `ExcelTable` and `ExcelSheet`, `available_columns`  is no longer a property. It is now a method, and information regarding available columns is computed on-demand (the information is cached after having been computed once).
* If `use_columns` is a callable, it no longer receives a `ColumnInfo` object, but a `ColumnInfoBuilder` instead (no dtype information).
* `ColumnInfoBuilder` is now part of the Python API.

@PrettyWood If you have a better naming suggestion for `ColumnInfoBuilder`, I'd love to hear it.  Maybe `ColumnNameInfo` or `ColumnInfoNoDtype` ?

closes #327 