### PR TITLE
Use split arrow crates for smaller dependency footprint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,39 +62,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
-name = "arrow"
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f15b4c6b148206ff3a2b35002e08929c2462467b62b9c02036d9c34f9ef994"
-dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ord",
- "arrow-pyarrow",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
-]
-
-[[package]]
-name = "arrow-arith"
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30feb679425110209ae35c3fbf82404a39a4c0436bb3ec36164d8bffed2a4ce4"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "num",
-]
-
-[[package]]
 name = "arrow-array"
 version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,26 +89,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-cast"
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f12eccc3e1c05a766cafb31f6a60a46c2f8efec9b74c6e0648766d30686af8"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "atoi",
- "base64",
- "chrono",
- "half",
- "lexical-core",
- "num",
- "ryu",
-]
-
-[[package]]
 name = "arrow-data"
 version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,19 +98,6 @@ dependencies = [
  "arrow-schema",
  "half",
  "num",
-]
-
-[[package]]
-name = "arrow-ord"
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6506e3a059e3be23023f587f79c82ef0bcf6d293587e3272d20f2d30b969b5a7"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
 ]
 
 [[package]]
@@ -179,65 +113,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-row"
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bf7393166beaf79b4bed9bfdf19e97472af32ce5b6b48169d321518a08cae2"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "half",
-]
-
-[[package]]
 name = "arrow-schema"
 version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7686986a3bf2254c9fb130c623cdcb2f8e1f15763e7c71c310f0834da3d292"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "arrow-select"
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2b45757d6a2373faa3352d02ff5b54b098f5e21dccebc45a21806bc34501e5"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "num",
-]
-
-[[package]]
-name = "arrow-string"
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0377d532850babb4d927a06294314b316e23311503ed580ec6ce6a0158f49d40"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "memchr",
- "num",
- "regex",
- "regex-syntax",
-]
-
-[[package]]
-name = "atoi"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -251,12 +132,6 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -420,7 +295,9 @@ checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 name = "fastexcel"
 version = "0.14.0"
 dependencies = [
- "arrow",
+ "arrow-array",
+ "arrow-pyarrow",
+ "arrow-schema",
  "calamine",
  "chrono",
  "log",
@@ -528,70 +405,6 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "lexical-core"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b765c31809609075565a70b4b71402281283aeda7ecaf4818ac14a7b2ade8958"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de6f9cb01fb0b08060209a057c048fcbab8717b4c1ecd2eac66ebfe39a65b0f2"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72207aae22fc0a121ba7b6d479e42cbfea549af1479c3f3a4f12c70dd66df12e"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-util"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a82e24bf537fd24c177ffbbdc6ebcc8d54732c35b50a3f28cc3f4e4c949a0b3"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-float"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5afc668a27f460fb45a81a757b6bf2f43c2d7e30cb5a2dcd3abf294c78d62bd"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629ddff1a914a836fb245616a7888b62903aae58fa771e1d83943035efa0f978"
-dependencies = [
- "lexical-util",
- "static_assertions",
 ]
 
 [[package]]
@@ -926,12 +739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
 name = "semver"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,12 +775,6 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,12 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # There's a lot of stuff we don't want here, such as serde support
-arrow = { version = "^55.2.0", default-features = false, features = ["ffi"] }
+# arrow = { version = "^55.2.0", default-features = false, features = ["ffi"] }
+arrow-schema = { version = "^55.2.0", default-features = false }
+arrow-array = { version = "^55.2.0", default-features = false, features = [
+    "ffi",
+] }
+arrow-pyarrow = { version = "^55.2.0", default-features = false, optional = true }
 calamine = { version = "^0.30.0", features = ["dates"] }
 chrono = { version = "^0.4.41", default-features = false }
 log = "0.4.27"
@@ -42,7 +47,7 @@ rstest = { version = "^0.26.1", default-features = false }
 [features]
 default = ["extension-module", "pyarrow"]
 extension-module = ["pyo3/extension-module"]
-pyarrow = ["arrow/pyarrow"]
+pyarrow = ["dep:arrow-pyarrow"]
 # feature for tests only. This makes Python::with_gil auto-initialize Python
 # interpreters, which allows us to instantiate Python objects in tests
 # (see https://pyo3.rs/v0.22.3/features#auto-initialize)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,9 @@ name = "fastexcel"
 crate-type = ["cdylib"]
 
 [dependencies]
-# There's a lot of stuff we don't want here, such as serde support
-# arrow = { version = "^55.2.0", default-features = false, features = ["ffi"] }
-arrow-schema = { version = "^55.2.0", default-features = false }
-arrow-array = { version = "^55.2.0", default-features = false, features = [
-    "ffi",
-] }
-arrow-pyarrow = { version = "^55.2.0", default-features = false, optional = true }
+arrow-schema = "^55.2.0"
+arrow-array = { version = "^55.2.0", features = ["ffi"] }
+arrow-pyarrow = { version = "^55.2.0", optional = true }
 calamine = { version = "^0.30.0", features = ["dates"] }
 chrono = { version = "^0.4.41", default-features = false }
 log = "0.4.27"

--- a/src/arrow_capsule.rs
+++ b/src/arrow_capsule.rs
@@ -1,8 +1,8 @@
 use std::ffi::c_void;
 
-use arrow::array::Array;
-use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
-use arrow::record_batch::RecordBatch;
+use arrow_array::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
+use arrow_array::{Array, RecordBatch, StructArray};
+use arrow_schema::Schema;
 use pyo3::exceptions::PyValueError;
 use pyo3::ffi::PyCapsule_New;
 use pyo3::prelude::*;
@@ -11,7 +11,7 @@ use pyo3::types::PyCapsule;
 /// Creates a PyCapsule containing an ArrowSchema
 pub fn schema_to_pycapsule<'py>(
     py: Python<'py>,
-    schema: &arrow::datatypes::Schema,
+    schema: &Schema,
 ) -> PyResult<Bound<'py, PyCapsule>> {
     let schema_ptr = Box::into_raw(Box::new(FFI_ArrowSchema::try_from(schema).map_err(
         |e| PyValueError::new_err(format!("Failed to convert schema to FFI format: {}", e)),
@@ -78,7 +78,7 @@ pub fn record_batch_to_pycapsules<'py>(
     let schema_capsule = schema_to_pycapsule(py, record_batch.schema().as_ref())?;
 
     // For record batches, we need to convert to a struct array
-    let struct_array = arrow::array::StructArray::from(record_batch.clone());
+    let struct_array = StructArray::from(record_batch.clone());
     let array_capsule = array_to_pycapsule(py, &struct_array)?;
 
     Ok((schema_capsule, array_capsule))

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
-use arrow::{
-    array::{Array, NullArray, RecordBatch},
-    datatypes::{Field, Schema},
-};
+use arrow_array::{Array, ArrayRef, NullArray, RecordBatch};
+use arrow_schema::{Field, Schema};
 use calamine::{Data as CalData, DataRef as CalDataRef, DataType, Range};
 
 use crate::{
@@ -77,7 +75,7 @@ mod array_impls {
     use std::fmt::Debug;
     use std::sync::Arc;
 
-    use arrow::array::{
+    use arrow_array::{
         Array, BooleanArray, Date32Array, DurationMillisecondArray, Float64Array, Int64Array,
         StringArray, TimestampMillisecondArray,
     };
@@ -570,10 +568,7 @@ pub(crate) fn record_batch_from_data_and_columns_with_errors(
         let dtype = *column_info.dtype();
 
         let (array, new_cell_errors) = match dtype {
-            DType::Null => (
-                Arc::new(NullArray::new(limit - offset)) as Arc<dyn arrow::array::Array>,
-                vec![],
-            ),
+            DType::Null => (Arc::new(NullArray::new(limit - offset)) as ArrayRef, vec![]),
             DType::Int => create_int_array_with_errors(data, col_idx, offset, limit),
             DType::Float => create_float_array_with_errors(data, col_idx, offset, limit),
             DType::String => create_string_array_with_errors(data, col_idx, offset, limit),

--- a/src/types/dtype.rs
+++ b/src/types/dtype.rs
@@ -5,7 +5,7 @@ use std::{
     sync::OnceLock,
 };
 
-use arrow::datatypes::{DataType as ArrowDataType, TimeUnit};
+use arrow_schema::{DataType as ArrowDataType, TimeUnit};
 use calamine::{CellErrorType, CellType, DataType, Range};
 use log::warn;
 use pyo3::{

--- a/src/types/python/excelreader.rs
+++ b/src/types/python/excelreader.rs
@@ -3,9 +3,9 @@ use std::{
     io::{BufReader, Cursor},
 };
 
+use arrow_array::RecordBatch;
 #[cfg(feature = "pyarrow")]
-use arrow::pyarrow::ToPyArrow;
-use arrow::record_batch::RecordBatch;
+use arrow_pyarrow::ToPyArrow;
 use pyo3::{Bound, IntoPyObjectExt, PyAny, PyResult, Python, pyclass, pymethods};
 
 use calamine::{

--- a/src/types/python/excelsheet/column_info.rs
+++ b/src/types/python/excelsheet/column_info.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, str::FromStr};
 
-use arrow::datatypes::Field;
+use arrow_schema::Field;
 use calamine::DataType;
 use pyo3::{PyResult, pyclass, pymethods};
 

--- a/src/types/python/excelsheet/mod.rs
+++ b/src/types/python/excelsheet/mod.rs
@@ -5,9 +5,9 @@ use calamine::{CellType, Range, Sheet as CalamineSheet, SheetVisible as Calamine
 use column_info::{AvailableColumns, ColumnInfoNoDtype};
 use std::{cmp, collections::HashSet, fmt::Debug, str::FromStr};
 
+use arrow_array::RecordBatch;
 #[cfg(feature = "pyarrow")]
-use arrow::pyarrow::ToPyArrow;
-use arrow::record_batch::RecordBatch;
+use arrow_pyarrow::ToPyArrow;
 
 use pyo3::{
     Bound, IntoPyObject, IntoPyObjectExt, PyAny, PyObject, PyResult,

--- a/src/types/python/table.rs
+++ b/src/types/python/table.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use arrow::array::{NullArray, RecordBatch};
+use arrow_array::{NullArray, RecordBatch};
 #[cfg(feature = "pyarrow")]
-use arrow::pyarrow::ToPyArrow;
+use arrow_pyarrow::ToPyArrow;
 use calamine::{Data, Range, Table};
 use pyo3::{Bound, PyAny, PyResult};
 use pyo3::{PyObject, Python, pyclass, pymethods};


### PR DESCRIPTION
The repo currently brings in all of the default features of the `arrow` crate. We can have faster compile times by only bringing in the relevant sub-crates.