### PR TITLE
build: Specify all maturin features in pyproject.toml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: "-o dist --features __maturin"
+          args: "-o dist"
           target: ${{ steps.target.outputs.target }}
 
       - name: Upload wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         manylinux: auto
         command: build
-        args: "--release -o dist --features __maturin"
+        args: "--release -o dist"
         target: ${{ matrix.architecture == 'aarch64' && 'aarch64-unknown-linux-gnu' || null }}
     - name: Upload wheels
       uses: actions/upload-artifact@v4
@@ -42,7 +42,7 @@ jobs:
       uses: PyO3/maturin-action@v1
       with:
         command: build
-        args: "--release -o dist --features __maturin"
+        args: "--release -o dist"
         target: ${{ matrix.architecture == 'aarch64' && 'aarch64-apple-darwin' || 'x86_64-apple-darwin' }}
     - name: Upload wheels
       uses: actions/upload-artifact@v4
@@ -63,7 +63,7 @@ jobs:
       uses: PyO3/maturin-action@v1
       with:
         command: build
-        args: "--release -o dist --features __maturin"
+        args: "--release -o dist"
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ export CARGO_TERM_COLOR=$(shell (test -t 0 && echo "always") || echo "auto")
 .PHONY: install  ## Install the package & dependencies with debug build
 install: .uv
 	uv sync --frozen --group all
-	uv run maturin develop --features __maturin --uv -E pandas,polars
+	uv run maturin develop --uv -E pandas,polars
 
 .PHONY: install-prod  ## Install the package & dependencies with release build
 install-prod: .uv
 	uv sync --frozen --group all
-	uv run maturin develop --features __maturin --uv --release -E pandas,polars
+	uv run maturin develop --uv --release -E pandas,polars
 
 .PHONY: setup-dev  ## First-time setup: install + pre-commit hooks
 setup-dev: install
@@ -28,12 +28,12 @@ rebuild-lockfiles: .uv
 
 .PHONY: build-dev  ## Build the development version of the package
 build-dev:
-	uv run maturin build --features __maturin
+	uv run maturin build
 
 .PHONY: build-wheel  ## Build production wheel and install it
 build-wheel:
 	@rm -rf target/wheels/
-	uv run maturin build --release --features __maturin
+	uv run maturin build --release
 	@wheel=$$(ls target/wheels/*.whl); uv pip install --force-reinstall "$$wheel[pandas,polars]"
 
 .PHONY: lint-python  ## Lint python source files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ Issues = "https://github.com/ToucanToco/fastexcel"
 [tool.maturin]
 python-source = "python"
 module-name = "fastexcel._fastexcel"
-features = ["pyo3/extension-module", "__maturin"]
+features = ["__maturin"]
 
 [tool.mypy]
 python_version = "3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ Issues = "https://github.com/ToucanToco/fastexcel"
 [tool.maturin]
 python-source = "python"
 module-name = "fastexcel._fastexcel"
-features = ["pyo3/extension-module"]
+features = ["pyo3/extension-module", "__maturin"]
 
 [tool.mypy]
 python_version = "3.9"


### PR DESCRIPTION
Specify all maturin specific features in pyproject.toml instead of cli arguments.

It simplifies deployment. It also makes conda package deployment simpler.