### PR TITLE
build: fix makefile for dev setup on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := all
 sources = python/fastexcel python/tests
 
-export CARGO_TERM_COLOR=$(shell (test -t 0 && echo "always") || echo "auto")
+export CARGO_TERM_COLOR=$(shell (test -t 0 && echo always) || echo auto)
 
 .PHONY: .uv  ## Check that uv is installed
 .uv:


### PR DESCRIPTION
Was getting this error when running `make setup-dev` on windows:
```powershell
uv run maturin develop --uv -E pyarrow,pandas,polars
error: argument for --color must be auto, always, or never, but found `"auto"`
💥 maturin failed
  Caused by: Cargo metadata failed. Does your crate compile with `cargo build`?
  Caused by: `cargo metadata` exited with an error:
make: *** [install] Error 1
```

This PR fixes the issue