### PR TITLE
- release python's GIL in read_excel and ExcelReader.build_sheet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,15 +30,15 @@ pub fn read_excel<S: AsRef<str> + Display>(path: S) -> FastExcelResult<ExcelRead
 #[cfg(feature = "python")]
 /// Reads an excel file and returns an object allowing to access its sheets, tables, and a bit of metadata
 #[pyfunction(name = "read_excel")]
-fn py_read_excel(source: &Bound<'_, PyAny>) -> PyResult<ExcelReader> {
+fn py_read_excel<'py>(source: &Bound<'_, PyAny>, py: Python<'py>) -> PyResult<ExcelReader> {
     use py_errors::IntoPyResult;
 
     if let Ok(path) = source.extract::<String>() {
-        ExcelReader::try_from_path(&path)
+        py.allow_threads(|| ExcelReader::try_from_path(&path))
             .with_context(|| format!("could not load excel file at {path}"))
             .into_pyresult()
     } else if let Ok(bytes) = source.extract::<&[u8]>() {
-        ExcelReader::try_from(bytes)
+        py.allow_threads(|| ExcelReader::try_from(bytes))
             .with_context(|| "could not load excel file for those bytes")
             .into_pyresult()
     } else {

--- a/src/types/excelreader/python.rs
+++ b/src/types/excelreader/python.rs
@@ -115,10 +115,12 @@ impl ExcelReader {
                 ))
             }
         } else {
-            let range = self
-                .sheets
-                .with_header_row(calamine_header_row)
-                .worksheet_range(&sheet_meta.name)
+            let range = py
+                .allow_threads(|| {
+                    self.sheets
+                        .with_header_row(calamine_header_row)
+                        .worksheet_range(&sheet_meta.name)
+                })
                 .into_pyresult()?;
             let pagination =
                 Pagination::try_new(opts.skip_rows, opts.n_rows, &range).into_pyresult()?;


### PR DESCRIPTION
Hi there, I was trying to use multiple threads to simultaneously extract many excel files and didn't see the all cores being used, so suspected that the GIL was not being released within fastexcel

I've added a GIL-releasing closure in two places as noted in the title: rust implementation of read_excel and ExcelReader.build_sheet

With these in place, I see all cores being used in a multi-threaded setup :)

I expect more could be done to release the GIL for longer, but I think I've covered the two major places where most time is spent without needing a wider refactor

Also apologies for confusion, commits have been made under the user jc-5s which is also mine (work account)

Thanks!