### PR TITLE
Deps: Update calamine dependency version to 0.34.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ crate-type = ["cdylib", "rlib"]
 arrow-array = { version = "^57", features = ["ffi"], optional = true }
 arrow-pyarrow = { version = "^57", optional = true }
 arrow-schema = { version = "^57", optional = true }
-calamine = { version = "^0.33.0", features = ["chrono"] }
+calamine = { version = "^0.34.0", features = ["chrono"] }
 chrono = { version = "^0.4.43", default-features = false }
 log = "^0.4"
 polars-core = { version = ">=0.50", default-features = false, features = [


### PR DESCRIPTION
Updates calamine dependency to version 0.34.0 

https://github.com/tafia/calamine/releases/tag/v0.34.0



